### PR TITLE
display CI badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Go
+name: CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[CI](https://github.com/expect-digital/go-mf2/actions/workflows/ci.yaml/badge.svg)
+
 # Message Format 2 Parser
 
 This parser parses the localized message strings based on the [Message Format 2 Draft](https://github.com/unicode-org/message-format-wg/blob/7c00820a0462679eba696181c45bfadb43d2eedd/spec/message.abnf) by the Message Format Working Group (MFWG).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[CI](https://github.com/expect-digital/go-mf2/actions/workflows/ci.yaml/badge.svg)
+![CI](https://github.com/expect-digital/go-mf2/actions/workflows/ci.yaml/badge.svg)
 
 # Message Format 2 Parser
 


### PR DESCRIPTION
Display CI badge in README - https://github.com/expect-digital/go-mf2/tree/display-badge