### PR TITLE
add golangci-lint conf

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,60 @@
+linters:
+  enable-all: true
+  disable:
+   - asasalint
+   - deadcode
+   - depguard
+   - dupl
+   - exhaustivestruct
+   - exhaustruct
+   - forbidigo
+   - funlen
+   - gci
+   - ginkgolinter
+   - goconst
+   - gochecknoglobals
+   - gochecknoinits
+   - gocyclo
+   - godox
+   - goerr113
+   - gofmt
+   - goheader
+   - goimports
+   - golint
+   - gomodguard
+   - gosmopolitan
+   - grouper
+   - ifshort
+   - inamedparam
+   - interfacer
+   - loggercheck
+   - maintidx
+   - maligned
+   - nlreturn
+   - nonamedreturns
+   - nosnakecase
+   - promlinter
+   - revive
+   - scopelint
+   - structcheck
+   - tagliatelle
+   - testableexamples
+   - testpackage
+   - thelper
+   - tparallel
+   - varcheck
+   - varnamelen
+   - wastedassign
+   - whitespace
+   - zerologlint
+linters-settings:
+  cyclop:
+    max-complexity: 30
+  govet:
+    enable-all: true
+  importas:
+    alias:
+      - pkg: go.expect.digital/translate/pkg/pb/translate/v1
+        alias: translatev1
+  predeclared:
+    ignore: ""

--- a/lex.go
+++ b/lex.go
@@ -97,10 +97,9 @@ func lex(input string) *lexer { return &lexer{input: input, line: 1} }
 //
 // See https://github.com/unicode-org/message-format-wg/blob/7c00820a0462679eba696181c45bfadb43d2eedd/spec/message.abnf
 type lexer struct {
-	input     string
-	item      item
-	pos, line int
-	prev      item // prev non-whitespace item
+	input      string
+	item, prev item // prev non-whitespace
+	pos, line  int
 
 	isFunction,
 	isExpression,
@@ -197,7 +196,7 @@ func lexPattern(singleMessage bool) func(*lexer) stateFn {
 		for {
 			r := l.next()
 
-			// cases sorted based on the frequency of rune occurance
+			// cases sorted based on the frequency of rune occurrence
 			switch {
 			default:
 				l.backup()
@@ -375,7 +374,6 @@ func lexName(l *lexer) stateFn {
 		case len(s) == 0 && r == '.':
 			s = string(r)
 			typ = itemKeyword
-
 		}
 	}
 }

--- a/lex_test.go
+++ b/lex_test.go
@@ -301,7 +301,7 @@ func Test_lex(t *testing.T) {
 func assertItems(t *testing.T, expected []item, l *lexer) {
 	t.Helper()
 
-	var logItems []func()
+	logItems := make([]func(), 0, len(expected))
 
 	for _, exp := range expected {
 		v := l.nextItem()


### PR DESCRIPTION
We run `golangci-lint` without conf.

I added it and rectified all lint issues.