### PR TITLE
Design And Initial Implementation of Default Function Registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module go.expect.digital/mf2
 
 go 1.18
 
-require github.com/stretchr/testify v1.8.4
+require (
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/text v0.14.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/template/example_test.go
+++ b/template/example_test.go
@@ -60,7 +60,7 @@ func ExampleTemplate_complexMessage() {
 		Name: "color",
 		FormatSignature: &registry.Signature{
 			// Mark that input/operand is required for a function
-			Input: true,
+			IsInputRequired: true,
 			// Set a validation function for the input/operand, in this
 			// scenario we want to ensure that the input is a string
 			ValidateInput: func(a any) error {
@@ -80,7 +80,7 @@ func ExampleTemplate_complexMessage() {
 			},
 		},
 		// Define the function
-		F: func(color any, options map[string]any) (any, error) {
+		Fn: func(color any, options map[string]any) (any, error) {
 			if options == nil {
 				return color, nil
 			}

--- a/template/registry/number.go
+++ b/template/registry/number.go
@@ -1,0 +1,231 @@
+package registry
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"golang.org/x/text/currency"
+)
+
+// https://github.com/unicode-org/message-format-wg/blob/122e64c2482b54b6eff4563120915e0f86de8e4d/spec/registry.xml#L147
+
+var numberRegistryF = &Func{
+	Name:           "number",
+	Description:    "Locale-sensitive number formatting",
+	F:              numberF,
+	MatchSignature: nil, // Not allowed to use in matching context
+	FormatSignature: &Signature{
+		Input: true,
+		ValidateInput: func(a any) error {
+			if _, err := castAs[float64](a); err != nil {
+				return fmt.Errorf("unsupported type: %T: %w", a, err)
+			}
+
+			return nil
+		},
+		Options: Options{
+			{
+				Name:           "compactDisplay",
+				Description:    `Only used when notation is "compact".`,
+				PossibleValues: []any{"short", "long"},
+				Default:        "short",
+			},
+			{
+				Name: "currency",
+				Description: `The currency to use in currency formatting.
+Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar,
+"EUR" for the euro, or "CNY" for the Chinese RMB — see the
+Current currency &amp; funds code list
+(https://www.unicode.org/cldr/charts/latest/supplemental/detailed_territory_currency_information.html).
+There is no default value; if the style is "currency", the currency property must be provided.`,
+				ValidateValue: func(a any) error {
+					_, err := castAs[currency.Unit](a)
+					return err
+				},
+			},
+			{
+				Name:           "currencyDisplay",
+				Description:    `How to display the currency in currency formatting.`,
+				PossibleValues: []any{"code", "symbol", "narrowSymbol", "name"},
+			},
+			{
+				Name: "currencySign",
+				Description: `In many locales, accounting format means to wrap the number with parentheses
+instead of appending a minus sign. You can enable this formatting by setting the
+currencySign option to "accounting".`,
+				PossibleValues: []any{"standard", "accounting"},
+				Default:        "standard",
+			},
+			{
+				Name:           "notation",
+				Description:    "The formatting that should be displayed for the number.",
+				PossibleValues: []any{"standard", "scientific", "engineering", "compact"},
+				Default:        "standard",
+			},
+			{
+				Name:        "numberingSystem",
+				Description: "Numbering system to use.",
+				PossibleValues: []any{
+					"arab", "arabext", "bali", "beng", "deva", "fullwide", "gujr", "guru",
+					"hanidec", "khmr", "knda", "laoo", "latn", "limb", "mlym", "mong", "mymr", "orya", "tamldec",
+					"telu", "thai", "tibt",
+				},
+			},
+			{
+				Name:           "signDisplay",
+				Description:    `When to display the sign for the number. "negative" value is Experimental.`,
+				PossibleValues: []any{"auto", "always", "exceptZero", "negative", "never"},
+				Default:        "auto",
+			},
+			{
+				Name:           "style",
+				Description:    "The formatting style to use.",
+				PossibleValues: []any{"decimal", "currency", "percent", "unit"},
+				Default:        "decimal",
+			},
+			{
+				Name: "unit",
+				Description: `The unit to use in unit formatting.
+Possible values are core unit identifiers, defined in UTS #35, Part 2, Section 6.
+A subset of units from the full list was selected for use in ECMAScript.
+Pairs of simple units can be concatenated with "-per-" to make a compound unit.
+There is no default value; if the style is "unit", the unit property must be provided.`,
+				ValidateValue: isPositiveInteger,
+			},
+			{
+				Name:           "unitDisplay",
+				Description:    "The unit formatting style to use in unit formatting.",
+				PossibleValues: []any{"long", "short", "narrow"},
+				Default:        "short",
+			},
+			{
+				Name: "minimumIntegerDigits",
+				Description: `The minimum number of integer digits to use.
+A value with a smaller number of integer digits than this number will be
+left-padded with zeros (to the specified length) when formatted.`,
+				ValidateValue: isPositiveInteger,
+				Default:       1,
+			},
+			{
+				Name: "minimumFractionDigits",
+				Description: `The minimum number of fraction digits to use.
+The default for plain number and percent formatting is 0;
+the default for currency formatting is the number of minor unit digits provided by
+the ISO 4217 currency code list (2 if the list doesn't provide that information).`,
+				ValidateValue: isPositiveInteger,
+			},
+			{
+				Name: "maximumFractionDigits",
+				Description: `The maximum number of fraction digits to use.
+The default for plain number formatting is the larger of minimumFractionDigits and 3;
+the default for currency formatting is the larger of minimumFractionDigits and the number of
+minor
+unit digits provided by the ISO 4217 currency code list (2 if the list doesn't provide that
+information);
+the default for percent formatting is the larger of minimumFractionDigits and 0.`,
+				ValidateValue: isPositiveInteger,
+			},
+			{
+				Name:          "minimumSignificantDigits",
+				Description:   `The minimum number of significant digits to use.`,
+				ValidateValue: isPositiveInteger,
+				Default:       1,
+			},
+			{
+				Name:          "maximumSignificantDigits",
+				Description:   `The maximum number of significant digits to use.`,
+				ValidateValue: isPositiveInteger,
+				Default:       21, //nolint:gomnd
+			},
+		},
+	},
+}
+
+// TODO: supports only style and signDisplay options.
+func numberF(input any, options map[string]any) (any, error) {
+	num, err := castAs[float64](input)
+	if err != nil {
+		return nil, fmt.Errorf("convert input to float64: %w", err)
+	}
+
+	if options == nil {
+		return num, nil
+	}
+
+	for optName := range options {
+		switch optName {
+		case "compactDisplay", "currency", "currencyDisplay", "currencySign", "notation", "numberingSystem",
+			"unit", "unitDisplay", "minimumIntegerDigits", "minimumFractionDigits",
+			"maximumFractionDigits", "minimumSignificantDigits", "maximumSignificantDigits":
+			return nil, fmt.Errorf("option '%s' is not implemented", optName)
+		}
+	}
+
+	var result string
+
+	style, ok := options["style"]
+	if !ok {
+		style = "decimal"
+	}
+
+	switch style {
+	case "decimal":
+		result = strconv.FormatFloat(num, 'f', -1, 64)
+	case "percent":
+		result = fmt.Sprintf("%.2f%%", num*100) //nolint:gomnd
+	default:
+		return nil, fmt.Errorf("option '%s' is not implemented", style)
+	}
+
+	if signDisplay, ok := options["signDisplay"].(string); ok {
+		switch signDisplay {
+		case "auto":
+		case "negative":
+		case "always":
+			if num >= 0 {
+				result = "+" + result
+			}
+		case "exceptZero":
+			if num > 0 {
+				result = "+" + result
+			}
+		case "never":
+			if num < 0 {
+				result = result[1:]
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// helpers
+
+// castAs tries to cast any value to the given type.
+func castAs[T any](val any) (T, error) {
+	var zeroVal T
+	typ := reflect.TypeOf(zeroVal)
+
+	v := (reflect.ValueOf(val))
+	if !v.Type().ConvertibleTo(typ) {
+		return zeroVal, fmt.Errorf("cannot convert %v to %T", v.Type(), zeroVal)
+	}
+
+	v = v.Convert(typ)
+
+	return v.Interface().(T), nil //nolint:forcetypeassert
+}
+
+func isPositiveInteger(v any) error {
+	val, err := castAs[int](v)
+	if err != nil {
+		return fmt.Errorf("convert val to int: %w", err)
+	}
+
+	if val < 0 {
+		return fmt.Errorf("value must be at least 0")
+	}
+
+	return nil
+}

--- a/template/registry/number.go
+++ b/template/registry/number.go
@@ -158,7 +158,7 @@ func numberF(input any, options map[string]any) (any, error) {
 		return nil, fmt.Errorf("convert input to float64: %w", err)
 	}
 
-	if options == nil {
+	if len(options) == 0 {
 		return num, nil
 	}
 

--- a/template/registry/number.go
+++ b/template/registry/number.go
@@ -13,10 +13,10 @@ import (
 var numberRegistryF = &Func{
 	Name:           "number",
 	Description:    "Locale-sensitive number formatting",
-	F:              numberF,
+	Fn:             numberF,
 	MatchSignature: nil, // Not allowed to use in matching context
 	FormatSignature: &Signature{
-		Input: true,
+		IsInputRequired: true,
 		ValidateInput: func(a any) error {
 			if _, err := castAs[float64](a); err != nil {
 				return fmt.Errorf("unsupported type: %T: %w", a, err)
@@ -40,8 +40,17 @@ Current currency &amp; funds code list
 (https://www.unicode.org/cldr/charts/latest/supplemental/detailed_territory_currency_information.html).
 There is no default value; if the style is "currency", the currency property must be provided.`,
 				ValidateValue: func(a any) error {
-					_, err := castAs[currency.Unit](a)
-					return err
+					unit, ok := a.(currency.Unit)
+					if !ok {
+						return fmt.Errorf("expected currency.Unit got %T", a)
+					}
+
+					var zeroVal currency.Unit
+					if unit == zeroVal {
+						return fmt.Errorf("currency is not set")
+					}
+
+					return nil
 				},
 			},
 			{

--- a/template/registry/number_test.go
+++ b/template/registry/number_test.go
@@ -1,0 +1,70 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Number(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input       any
+		options     map[string]any
+		expected    any
+		name        string
+		expectedErr bool
+	}{
+		// positive
+		{
+			name:     "int",
+			input:    53,
+			expected: float64(53),
+		},
+		{
+			name:     "style",
+			input:    0.23,
+			options:  map[string]any{"style": "percent"},
+			expected: "23.00%",
+		},
+		{
+			name:     "signDisplay and percent style",
+			input:    0.23,
+			options:  map[string]any{"style": "percent", "signDisplay": "always"},
+			expected: "+23.00%",
+		},
+		// negative
+		{
+			name:        "not implemented",
+			input:       0.23,
+			options:     map[string]any{"compactDisplay": "short"},
+			expectedErr: true,
+		},
+		{
+			name:        "illegal type",
+			input:       struct{}{},
+			options:     nil,
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := numberRegistryF.Format(tt.input, tt.options)
+
+			if tt.expectedErr {
+				require.Error(t, err)
+				require.Empty(t, actual)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/template/registry/registry.go
+++ b/template/registry/registry.go
@@ -1,0 +1,153 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type Registry []Func
+
+// Func is a function that can be used in formatting and matching contexts.
+type Func struct {
+	FormatSignature *Signature                             // Signature of the function when called in formatting context
+	MatchSignature  *Signature                             // Signature of the function when called in matching context
+	F               func(any, map[string]any) (any, error) // Function itself
+	Name            string
+	Description     string
+}
+
+// Signature is a signature of the function, i.e. what input and options are allowed.
+type Signature struct {
+	ValidateInput func(any) error // Only when input is true
+	Options       Options         // Possible options for the function
+	Input         bool            // If true, input is required
+}
+
+// Option is a possible options for the function.
+type Option struct {
+	Name        string
+	Description string
+	Default     any
+
+	ValidateValue  func(any) error // If option value is not restricted by a set of values.
+	PossibleValues []any           // If option value is restricted by a set of values.
+}
+
+type Options []Option
+
+func NewRegistry() Registry {
+	return []Func{
+		*stringRegistryF,
+		*numberRegistryF,
+	}
+}
+
+func (r Registry) Find(name string) (Func, bool) {
+	for _, fn := range r {
+		if fn.Name == name {
+			return fn, true
+		}
+	}
+
+	return Func{}, false
+}
+
+func (r *Func) Format(input any, options map[string]any) (any, error) {
+	if r.FormatSignature == nil {
+		return "", fmt.Errorf("function '%s' is not allowed to use in formatting context", r.Name)
+	}
+
+	if err := r.FormatSignature.check(input, options); err != nil {
+		return "", fmt.Errorf("check input: %w", err)
+	}
+
+	return r.F(input, options)
+}
+
+func (r *Func) Match(input any, options map[string]any) (any, error) {
+	if r.MatchSignature == nil {
+		return "", fmt.Errorf("function '%s' is not allowed to use in selector context", r.Name)
+	}
+
+	if err := r.MatchSignature.check(input, options); err != nil {
+		return "", fmt.Errorf("check input: %w", err)
+	}
+
+	return r.F(input, options)
+}
+
+func (s *Signature) check(input any, options map[string]any) error {
+	if s.Input && input == nil {
+		return errors.New("input is nil, but required")
+	}
+
+	if !s.Input && input != nil {
+		return errors.New("input is not allowed")
+	}
+
+	if s.Options == nil && len(options) > 0 {
+		return errors.New("options are not allowed")
+	}
+
+	if s.ValidateInput != nil {
+		if err := s.ValidateInput(input); err != nil {
+			return fmt.Errorf("validate input: %w", err)
+		}
+	}
+
+	if len(options) > 0 {
+		if err := s.Options.check(options); err != nil {
+			return fmt.Errorf("check options: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (o Options) check(got map[string]any) error {
+	for name, val := range got {
+		opt, ok := o.find(name)
+		if !ok {
+			validOptions := make([]string, 0, len(o))
+			for _, opt := range o {
+				validOptions = append(validOptions, opt.Name)
+			}
+
+			return fmt.Errorf("unknown option: '%s'. Valid options: [%s]", name, strings.Join(validOptions, ", "))
+		}
+
+		if opt.ValidateValue != nil {
+			if err := opt.ValidateValue(val); err != nil {
+				return fmt.Errorf("validate options value '%s': %w", name, err)
+			}
+		}
+
+		if len(opt.PossibleValues) > 0 {
+			var found bool
+
+			for _, possible := range opt.PossibleValues {
+				if possible == val {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("invalid value '%s' for option '%s'. Valid values: %s  ", val, name, opt.PossibleValues)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (o Options) find(name string) (Option, bool) {
+	for _, opt := range o {
+		if opt.Name == name {
+			return opt, true
+		}
+	}
+
+	return Option{}, false
+}

--- a/template/registry/registry.go
+++ b/template/registry/registry.go
@@ -36,8 +36,8 @@ type Option struct {
 
 type Options []Option
 
-// NewRegistry returns a new registry with default functions.
-func NewRegistry() Registry {
+// New returns a new registry with default functions.
+func New() Registry {
 	return Registry{
 		"string": *stringRegistryF,
 		"number": *numberRegistryF,

--- a/template/registry/registry.go
+++ b/template/registry/registry.go
@@ -87,10 +87,8 @@ func (s *Signature) check(input any, options map[string]any) error {
 		}
 	}
 
-	if len(options) > 0 {
-		if err := s.Options.check(options); err != nil {
-			return fmt.Errorf("check options: %w", err)
-		}
+	if err := s.Options.check(options); err != nil {
+		return fmt.Errorf("check options: %w", err)
 	}
 
 	return nil

--- a/template/registry/string.go
+++ b/template/registry/string.go
@@ -1,0 +1,31 @@
+package registry
+
+import "fmt"
+
+// https://github.com/unicode-org/message-format-wg/blob/122e64c2482b54b6eff4563120915e0f86de8e4d/spec/registry.xml#L259
+
+var stringRegistryF = &Func{
+	Name:            "string",
+	Description:     "Formatting of strings as a literal and selection based on string equality",
+	FormatSignature: &Signature{Input: true}, // Not nil, but empty
+	MatchSignature:  &Signature{Input: true}, // Not nil, but empty
+	F:               stringF,
+}
+
+func stringF(input any, _ map[string]any) (any, error) {
+	switch v := input.(type) {
+	case fmt.Stringer:
+		return v.String(), nil
+	case string, []byte, []rune, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64, float32, float64, bool,
+		complex64, complex128, error, nil:
+		return fmt.Sprint(v), nil
+	default:
+		val, err := castAs[string](input) // if underlying type is not string, return error
+		if err != nil {
+			return nil, fmt.Errorf("unsupported type: %T: %w", input, err)
+		}
+
+		return val, nil
+	}
+}

--- a/template/registry/string.go
+++ b/template/registry/string.go
@@ -7,9 +7,9 @@ import "fmt"
 var stringRegistryF = &Func{
 	Name:            "string",
 	Description:     "Formatting of strings as a literal and selection based on string equality",
-	FormatSignature: &Signature{Input: true},
-	MatchSignature:  &Signature{Input: true},
-	F:               stringF,
+	FormatSignature: &Signature{IsInputRequired: true},
+	MatchSignature:  &Signature{IsInputRequired: true},
+	Fn:              stringF,
 }
 
 func stringF(input any, _ map[string]any) (any, error) {

--- a/template/registry/string.go
+++ b/template/registry/string.go
@@ -7,8 +7,8 @@ import "fmt"
 var stringRegistryF = &Func{
 	Name:            "string",
 	Description:     "Formatting of strings as a literal and selection based on string equality",
-	FormatSignature: &Signature{Input: true}, // Not nil, but empty
-	MatchSignature:  &Signature{Input: true}, // Not nil, but empty
+	FormatSignature: &Signature{Input: true},
+	MatchSignature:  &Signature{Input: true},
 	F:               stringF,
 }
 

--- a/template/registry/string_test.go
+++ b/template/registry/string_test.go
@@ -1,0 +1,66 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       any
+		options     map[string]any
+		expected    string
+		expectedErr bool
+	}{
+		// positive
+		{
+			name:     "int",
+			input:    53,
+			options:  nil,
+			expected: "53",
+		},
+		{
+			name:     "date",
+			input:    time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+			options:  nil,
+			expected: "2021-01-01 00:00:00 +0000 UTC",
+		},
+		// negative
+		{
+			name:        "illegal type", // does not implement stringer, and is not castable to string
+			input:       struct{}{},
+			options:     nil,
+			expectedErr: true,
+		},
+		{
+			name:        "illegal options", // string function does not support any options
+			input:       2,
+			options:     map[string]any{"will": "fail"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := stringRegistryF.Format(tt.input, tt.options)
+
+			if tt.expectedErr {
+				require.Error(t, err)
+				require.Empty(t, actual)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/template/template.go
+++ b/template/template.go
@@ -81,7 +81,7 @@ func (t *Template) Sprint(input map[string]any) (string, error) {
 
 // New returns a new Template.
 func New() *Template {
-	return &Template{funcRegistry: registry.NewRegistry()}
+	return &Template{funcRegistry: registry.New()}
 }
 
 type executer struct {

--- a/template/template.go
+++ b/template/template.go
@@ -42,7 +42,7 @@ type Template struct {
 
 // AddFunc adds a function to the template's function map.
 func (t *Template) AddFunc(f registry.Func) {
-	t.funcRegistry = append(t.funcRegistry, f)
+	t.funcRegistry[f.Name] = f
 }
 
 // Parse parses the MessageFormat2 string and returns the template.
@@ -257,7 +257,7 @@ func (e *executer) resolveAnnotation(operand any, annotation ast.Annotation) (st
 		return "", fmt.Errorf("%w with %T annotation: '%s'", ErrUnsupportedExpression, annotation, annotation)
 	}
 
-	registryF, ok := e.template.funcRegistry.Find(annoFn.Identifier.Name)
+	registryF, ok := e.template.funcRegistry[annoFn.Identifier.Name]
 	if !ok {
 		return "", fmt.Errorf("%w '%s'", ErrUnknownFunction, annoFn.Identifier.Name)
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	ast "go.expect.digital/mf2/parse"
+	"go.expect.digital/mf2/template/registry"
 )
 
 // MessageFormat2 Errors as defined in the specification.
@@ -28,13 +29,20 @@ type Func func(operand any, options map[string]any) (string, error)
 
 // Template represents a MessageFormat2 template.
 type Template struct {
-	ast   *ast.AST
-	funcs map[string]Func
+	// TODO: locale field. Can change the output of some functions.
+	// e.g. number formatting, given example { $num :number }:
+	//  - "en-US" -> 1,234.56
+	//  - "lv-LV" -> 1234,56
+	// e.g. date formatting, given example { $date :datetime }:
+	//  - "en-US" -> 1/2/2023
+	//  - "lv-LV" -> 2.1.2023
+	ast          *ast.AST
+	funcRegistry registry.Registry
 }
 
 // AddFunc adds a function to the template's function map.
-func (t *Template) AddFunc(name string, f Func) {
-	t.funcs[name] = f
+func (t *Template) AddFunc(f registry.Func) {
+	t.funcRegistry = append(t.funcRegistry, f)
 }
 
 // Parse parses the MessageFormat2 string and returns the template.
@@ -72,7 +80,9 @@ func (t *Template) Sprint(input map[string]any) (string, error) {
 }
 
 // New returns a new Template.
-func New() *Template { return &Template{funcs: make(map[string]Func)} }
+func New() *Template {
+	return &Template{funcRegistry: registry.NewRegistry()}
+}
 
 type executer struct {
 	template *Template
@@ -128,7 +138,7 @@ func (e *executer) resolveDeclarations(declarations []ast.Declaration) error {
 			return fmt.Errorf("%w: '%s'", ErrUnsupportedStatement, "reserved statement")
 		case ast.LocalDeclaration:
 			if _, ok := m[d.Variable]; ok {
-				return fmt.Errorf("%w '%s'", ErrDuplicateDeclaration, "duplicate declaration")
+				return fmt.Errorf("%w '%s'", ErrDuplicateDeclaration, d)
 			}
 
 			m[d.Variable] = struct{}{}
@@ -142,7 +152,7 @@ func (e *executer) resolveDeclarations(declarations []ast.Declaration) error {
 
 		case ast.InputDeclaration:
 			if _, ok := m[d.Operand]; ok {
-				return fmt.Errorf("%w '%s'", ErrDuplicateDeclaration, "duplicate declaration")
+				return fmt.Errorf("%w '%s'", ErrDuplicateDeclaration, d)
 			}
 
 			m[d.Operand] = struct{}{}
@@ -247,7 +257,7 @@ func (e *executer) resolveAnnotation(operand any, annotation ast.Annotation) (st
 		return "", fmt.Errorf("%w with %T annotation: '%s'", ErrUnsupportedExpression, annotation, annotation)
 	}
 
-	fn, ok := e.template.funcs[annoFn.Identifier.Name]
+	registryF, ok := e.template.funcRegistry.Find(annoFn.Identifier.Name)
 	if !ok {
 		return "", fmt.Errorf("%w '%s'", ErrUnknownFunction, annoFn.Identifier.Name)
 	}
@@ -257,12 +267,12 @@ func (e *executer) resolveAnnotation(operand any, annotation ast.Annotation) (st
 		return "", fmt.Errorf("resolve options: %w", err)
 	}
 
-	result, err := fn(operand, opts)
+	result, err := registryF.Format(operand, opts)
 	if err != nil {
 		return "", fmt.Errorf("%w: %s", ErrFormatting, err.Error())
 	}
 
-	return result, nil
+	return fmt.Sprint(result), nil
 }
 
 func (e *executer) resolveOptions(options []ast.Option) (map[string]any, error) {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,18 +1,12 @@
 package template
 
 import (
-	"fmt"
-	"strings"
+	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.expect.digital/mf2/template/registry"
 )
-
-type fn struct {
-	f    Func
-	name string
-}
 
 func Test_ExecuteSimpleMessage(t *testing.T) {
 	t.Parallel()
@@ -26,7 +20,7 @@ func Test_ExecuteSimpleMessage(t *testing.T) {
 		name     string
 		args     args
 		expected string
-		funcs    []fn // exec functions to be added before executing
+		funcs    []registry.Func // format functions to be added before executing
 	}{
 		{
 			name: "empty message",
@@ -55,87 +49,28 @@ func Test_ExecuteSimpleMessage(t *testing.T) {
 		{
 			name: "functions with operand",
 			args: args{
-				inputStr: "Hello, { $firstName :upper } { $secondName :lower style=first } { $date :date }!",
+				inputStr: "Hello, { $firstName :string } your age is { $age :number style=decimal }!",
 				inputMap: map[string]any{
-					"firstName":  "John",
-					"secondName": "Doe",
-					"date":       time.Date(2021, 9, 1, 0, 0, 0, 0, time.UTC),
+					"firstName": "John",
+					"age":       23,
 				},
 			},
-			funcs: []fn{
-				{
-					name: "upper",
-					f: func(v any, _ map[string]any) (string, error) {
-						return strings.ToUpper(fmt.Sprint(v)), nil
-					},
-				},
-				{
-					name: "lower",
-					f: func(v any, opts map[string]any) (string, error) {
-						if opts == nil {
-							return strings.ToLower(fmt.Sprint(v)), nil
-						}
-
-						if style, ok := opts["style"].(string); ok {
-							switch style {
-							case "first":
-								return strings.ToLower(fmt.Sprint(v)[0:1]) + fmt.Sprint(v)[1:], nil
-							default:
-								return "", fmt.Errorf("unsupported style: %s", style)
-							}
-						}
-
-						return "", nil
-					},
-				},
-				{
-					name: "date",
-					f: func(v any, _ map[string]any) (string, error) {
-						date, ok := v.(time.Time)
-						if !ok {
-							return "", fmt.Errorf("unsupported type: %T", v)
-						}
-
-						return date.Format("2006-01-02"), nil
-					},
-				},
-			},
-			expected: "Hello, JOHN doe 2021-09-01!",
+			expected: "Hello, John your age is 23!",
 		},
 		{
 			name: "function without operand",
 			args: args{
-				inputStr: "Hello, { :randFirstName } { :randSecondName style=caps }!",
+				inputStr: "Hello, { :randName }",
 				inputMap: nil,
 			},
-			funcs: []fn{
+			funcs: []registry.Func{
 				{
-					name: "randFirstName",
-					f: func(_ any, _ map[string]any) (string, error) {
-						return "John", nil
-					},
-				},
-				{
-					name: "randSecondName",
-					f: func(_ any, opts map[string]any) (string, error) {
-						if opts == nil {
-							return "Doe", nil
-						}
-
-						if style, ok := opts["style"].(string); ok {
-							switch style {
-							case "caps":
-								return "DOE", nil
-							default:
-								return "", fmt.Errorf("unsupported style: %s", style)
-							}
-						}
-
-						return "", nil
-					},
+					Name:            "randName",
+					FormatSignature: &registry.Signature{},
+					F:               func(_ any, _ map[string]any) (any, error) { return "John", nil },
 				},
 			},
-			expected: "Hello, John DOE!",
+			expected: "Hello, John",
 		},
 	}
 
@@ -148,7 +83,7 @@ func Test_ExecuteSimpleMessage(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, f := range tt.funcs {
-				template.AddFunc(f.name, f.f)
+				template.AddFunc(f)
 			}
 
 			actual, err := template.Sprint(tt.args.inputMap)
@@ -171,7 +106,7 @@ func Test_ExecuteComplexMessage(t *testing.T) {
 		name     string
 		args     args
 		expected string
-		funcs    []fn // exec functions to be added before executing
+		funcs    []registry.Func // format functions to be added before executing
 	}{
 		{
 			name: "complex message without declaration",
@@ -190,12 +125,11 @@ func Test_ExecuteComplexMessage(t *testing.T) {
 		{{Hello, {$var1} {$var2} {$var3}!}}`,
 				inputMap: map[string]any{"anotherVar": "World"},
 			},
-			funcs: []fn{
+			funcs: []registry.Func{
 				{
-					name: "randNum",
-					f: func(_ any, _ map[string]any) (string, error) {
-						return "0", nil
-					},
+					Name:            "randNum",
+					FormatSignature: &registry.Signature{},
+					F:               func(_ any, _ map[string]any) (any, error) { return 0, nil },
 				},
 			},
 			expected: "Hello, literalExpression World 0!",
@@ -203,18 +137,10 @@ func Test_ExecuteComplexMessage(t *testing.T) {
 		{
 			name: "input declaration",
 			args: args{
-				inputStr: ".input { $name :upper } {{Hello, {$name}!}}",
-				inputMap: map[string]any{"name": "john"},
+				inputStr: ".input { $name :string } {{Hello, {$name}!}}",
+				inputMap: map[string]any{"name": 999},
 			},
-			funcs: []fn{
-				{
-					name: "upper",
-					f: func(v any, _ map[string]any) (string, error) {
-						return strings.ToUpper(fmt.Sprint(v)), nil
-					},
-				},
-			},
-			expected: "Hello, JOHN!",
+			expected: "Hello, 999!",
 		},
 	}
 
@@ -227,7 +153,7 @@ func Test_ExecuteComplexMessage(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, f := range tt.funcs {
-				template.AddFunc(f.name, f.f)
+				template.AddFunc(f)
 			}
 
 			actual, err := template.Sprint(tt.args.inputMap)
@@ -251,7 +177,7 @@ func Test_ExecuteErrors(t *testing.T) {
 		expectedParseErr   error
 		expectedExecuteErr error
 		args               args
-		fn                 fn // exec function to be added before executing
+		fn                 []registry.Func // format function to be added before executing
 	}{
 		{
 			name: "syntax error",
@@ -280,14 +206,10 @@ func Test_ExecuteErrors(t *testing.T) {
 		{
 			name: "duplicate option name",
 			args: args{
-				inputStr: "Hello, { :existing style=first style=second }!",
+				inputStr: "Hello, { :number style=decimal style=percent }!",
 				inputMap: nil,
 			},
 			expectedExecuteErr: ErrDuplicateOptionName,
-			fn: fn{
-				name: "existing",
-				f:    func(any, map[string]any) (string, error) { return "", nil },
-			},
 		},
 		{
 			name: "unsupported expression",
@@ -304,9 +226,12 @@ func Test_ExecuteErrors(t *testing.T) {
 				inputMap: nil,
 			},
 			expectedExecuteErr: ErrFormatting,
-			fn: fn{
-				name: "error",
-				f:    func(any, map[string]any) (string, error) { return "", fmt.Errorf("error occurred") },
+			fn: []registry.Func{
+				{
+					Name:            "error",
+					FormatSignature: &registry.Signature{},
+					F:               func(any, map[string]any) (any, error) { return nil, errors.New("error") },
+				},
 			},
 		},
 		{
@@ -346,7 +271,9 @@ func Test_ExecuteErrors(t *testing.T) {
 				return
 			}
 
-			template.AddFunc(tt.fn.name, tt.fn.f)
+			for _, f := range tt.fn {
+				template.AddFunc(f)
+			}
 
 			_, err = template.Sprint(tt.args.inputMap)
 			require.ErrorIs(t, err, tt.expectedExecuteErr)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -67,7 +67,7 @@ func Test_ExecuteSimpleMessage(t *testing.T) {
 				{
 					Name:            "randName",
 					FormatSignature: &registry.Signature{},
-					F:               func(_ any, _ map[string]any) (any, error) { return "John", nil },
+					Fn:              func(_ any, _ map[string]any) (any, error) { return "John", nil },
 				},
 			},
 			expected: "Hello, John",
@@ -129,7 +129,7 @@ func Test_ExecuteComplexMessage(t *testing.T) {
 				{
 					Name:            "randNum",
 					FormatSignature: &registry.Signature{},
-					F:               func(_ any, _ map[string]any) (any, error) { return 0, nil },
+					Fn:              func(_ any, _ map[string]any) (any, error) { return 0, nil },
 				},
 			},
 			expected: "Hello, literalExpression World 0!",
@@ -230,7 +230,7 @@ func Test_ExecuteErrors(t *testing.T) {
 				{
 					Name:            "error",
 					FormatSignature: &registry.Signature{},
-					F:               func(any, map[string]any) (any, error) { return nil, errors.New("error") },
+					Fn:              func(any, map[string]any) (any, error) { return nil, errors.New("error") },
 				},
 			},
 		},


### PR DESCRIPTION
Initial implementation design for integrating functions (default and custom) into the template:

Currently, only two functions have been included:

- `string`
- `number` (though not fully implemented due to complexity in accommodating all options