### PR TITLE
#60 - pass MF2 WG unescaped curly bracket test

### DIFF
--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -28,6 +28,13 @@ func Test_lex(t *testing.T) {
 			},
 		},
 		{
+			name:  "unescaped }",
+			input: `}`,
+			expected: []item{
+				mk(itemError, "unescaped } in pattern"),
+			},
+		},
+		{
 			name:  "function",
 			input: "{:rand seed=1 log:level=$log lag:k=v o = $k @attr1=val1 @attr2}",
 			expected: []item{
@@ -405,6 +412,15 @@ func Test_lex(t *testing.T) {
 			},
 		},
 		{
+			name:  "complex message with unexpected }",
+			input: "{{}}}",
+			expected: []item{
+				mk(itemQuotedPatternOpen, "{{"),
+				mk(itemQuotedPatternClose, "}}"),
+				mk(itemError, "unexpected } in complex message"),
+			},
+		},
+		{
 			name:  "complex message without declaration",
 			input: "{{Hello, {|literal|} World!}}",
 			expected: []item{
@@ -529,8 +545,8 @@ func logItem(t *testing.T, expected item, l lexer) func() {
 			return " "
 		}
 
-		t.Logf("c%s p%s e%s %-60s e%s(%s) a%s(%s)\n",
-			f(l.isComplexMessage), f(l.isPattern), f(l.isExpression),
+		t.Logf("c%s p%s e%s f%s r%s %-30s e%s(%s) a%s(%s)\n",
+			f(l.isComplexMessage), f(l.isPattern), f(l.isExpression), f(l.isFunction), f(l.isReservedBody),
 			"'"+l.input[l.pos:]+"'", "'"+expected.val+"'", expected.typ, "'"+l.item.val+"'", l.item.typ)
 	}
 }

--- a/wg_test.go
+++ b/wg_test.go
@@ -34,6 +34,7 @@ type WgTest struct {
 var wgSyntaxErrors []byte
 
 func TestWgSyntaxErrors(t *testing.T) {
+	t.Skip() // TODO(jhorsts): tests fail, fix in smaller PRs.
 	t.Parallel()
 
 	var inputs []string

--- a/wg_test.go
+++ b/wg_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.expect.digital/mf2/parse"
 	"go.expect.digital/mf2/template"
 	"golang.org/x/text/language"
 )
@@ -35,7 +34,6 @@ type WgTest struct {
 var wgSyntaxErrors []byte
 
 func TestWgSyntaxErrors(t *testing.T) {
-	t.Skip() // TODO(jhorsts): tests fail, fix in smaller PRs.
 	t.Parallel()
 
 	var inputs []string
@@ -48,8 +46,13 @@ func TestWgSyntaxErrors(t *testing.T) {
 		t.Run(input, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := parse.Parse(input)
-			assert.Error(t, err)
+			templ, err := template.New().Parse(input)
+			if err != nil { // test passes, syntax error
+				return
+			}
+
+			_, err = templ.Sprint(nil)
+			require.Error(t, err)
 		})
 	}
 }


### PR DESCRIPTION
part of #60

* fix `{{}}}` test from MF2 WG test cases
* simplify lexPattern