### PR TITLE
enable MF2 WG syntax errors tests

### DIFF
--- a/wg_test.go
+++ b/wg_test.go
@@ -34,7 +34,6 @@ type WgTest struct {
 var wgSyntaxErrors []byte
 
 func TestWgSyntaxErrors(t *testing.T) {
-	t.Skip() // TODO(jhorsts): tests fail, fix in smaller PRs.
 	t.Parallel()
 
 	var inputs []string


### PR DESCRIPTION
All MF2 WG `syntax errors` tests pass now. #60 