### PR TITLE
#60 - pass "{$one} et {$two}" MF2 WG core test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,7 @@ linters-settings:
       - generic
       - stdlib
       - (or|er)$
+      - Literal # false reporting in parseLiteral() by nolintlint
   predeclared:
     ignore: ""
   exhaustive:

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -739,7 +739,7 @@ func (p *parser) parseAttribute() (Attribute, error) {
 	return attribute, nil
 }
 
-func (p *parser) parseLiteral() (Literal, error) { //nolint:ireturn
+func (p *parser) parseLiteral() (Literal, error) {
 	switch itm := p.current(); itm.typ {
 	default:
 		return nil, unexpectedErr(itm, itemNumberLiteral, itemQuotedLiteral, itemUnquotedLiteral)

--- a/template/example_test.go
+++ b/template/example_test.go
@@ -6,6 +6,7 @@ import (
 
 	"go.expect.digital/mf2/template"
 	"go.expect.digital/mf2/template/registry"
+	"golang.org/x/text/language"
 )
 
 func ExampleTemplate_plainText() {
@@ -49,12 +50,6 @@ func ExampleTemplate_complexMessage() {
 .input { $color :color style=RGB}
 {{John is { $age } years old and his favorite color is { $color }.}}`
 
-	// Parse template.
-	t, err := template.New().Parse(input)
-	if err != nil {
-		panic(err)
-	}
-
 	// Define new function color
 	colorF := registry.Func{
 		Name: "color",
@@ -80,7 +75,7 @@ func ExampleTemplate_complexMessage() {
 			},
 		},
 		// Define the function
-		Fn: func(color any, options map[string]any) (any, error) {
+		Fn: func(color any, options map[string]any, locale language.Tag) (any, error) {
 			if options == nil {
 				return color, nil
 			}
@@ -112,7 +107,11 @@ func ExampleTemplate_complexMessage() {
 		},
 	}
 
-	t.AddFunc(colorF)
+	// Parse template.
+	t, err := template.New(template.WithFunc(colorF)).Parse(input)
+	if err != nil {
+		panic(err)
+	}
 
 	// Execute the template.
 	if err = t.Execute(os.Stdout, map[string]any{"color": "red"}); err != nil {

--- a/template/example_test.go
+++ b/template/example_test.go
@@ -75,7 +75,7 @@ func ExampleTemplate_complexMessage() {
 			},
 		},
 		// Define the function
-		Fn: func(color any, options map[string]any, locale language.Tag) (any, error) {
+		Func: func(color any, options map[string]any, locale language.Tag) (any, error) {
 			if options == nil {
 				return color, nil
 			}

--- a/template/registry/datetime.go
+++ b/template/registry/datetime.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"golang.org/x/text/language"
 )
 
 // https://github.com/unicode-org/message-format-wg/blob/20a61b4af534acb7ecb68a3812ca0143b34dfc76/spec/registry.xml#L13
@@ -125,7 +127,7 @@ such as "Asia/Shanghai", "Asia/Kolkata", "America/New_York".`,
 	},
 }
 
-func datetimeF(a any, options map[string]any) (any, error) {
+func datetimeF(a any, options map[string]any, locale language.Tag) (any, error) {
 	if len(options) == 0 {
 		return fmt.Sprint(a), nil
 	}

--- a/template/registry/datetime.go
+++ b/template/registry/datetime.go
@@ -13,7 +13,7 @@ import (
 var datetimeRegistryF = &Func{
 	Name:           "datetime",
 	Description:    "Locale-sensitive date and time formatting",
-	Fn:             datetimeF,
+	Func:           datetimeF,
 	MatchSignature: nil, // Not allowed to use in matching context
 	FormatSignature: &Signature{
 		IsInputRequired: true,

--- a/template/registry/datetime_test.go
+++ b/template/registry/datetime_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
 )
 
 var testDate = time.Date(2021, 1, 2, 3, 4, 5, 6, time.UTC)
@@ -69,7 +70,7 @@ func Test_Datetime(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := datetimeRegistryF.Format(tt.input, tt.options)
+			actual, err := datetimeRegistryF.Format(tt.input, tt.options, language.AmericanEnglish)
 
 			if tt.expectedErr {
 				require.Error(t, err)

--- a/template/registry/number.go
+++ b/template/registry/number.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
 
 	"golang.org/x/text/currency"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+	"golang.org/x/text/number"
 )
 
 // https://github.com/unicode-org/message-format-wg/blob/20a61b4af534acb7ecb68a3812ca0143b34dfc76/spec/registry.xml#L147
@@ -153,7 +155,7 @@ the default for percent formatting is the larger of minimumFractionDigits and 0.
 }
 
 // TODO: supports only style and signDisplay options.
-func numberF(input any, options map[string]any) (any, error) {
+func numberF(input any, options map[string]any, locale language.Tag) (any, error) {
 	num, err := castAs[float64](input)
 	if err != nil {
 		return nil, fmt.Errorf("convert input to float64: %w", err)
@@ -179,9 +181,11 @@ func numberF(input any, options map[string]any) (any, error) {
 		style = "decimal"
 	}
 
+	p := message.NewPrinter(locale)
+
 	switch style {
 	case "decimal":
-		result = strconv.FormatFloat(num, 'f', -1, 64)
+		result = p.Sprint(number.Decimal(num))
 	case "percent":
 		result = fmt.Sprintf("%.2f%%", num*100) //nolint:gomnd
 	default:

--- a/template/registry/number.go
+++ b/template/registry/number.go
@@ -16,7 +16,7 @@ import (
 var numberRegistryF = &Func{
 	Name:           "number",
 	Description:    "Locale-sensitive number formatting",
-	Fn:             numberF,
+	Func:           numberF,
 	MatchSignature: nil, // Not allowed to use in matching context
 	FormatSignature: &Signature{
 		IsInputRequired: true,

--- a/template/registry/number_test.go
+++ b/template/registry/number_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
 )
 
 func Test_Number(t *testing.T) {
@@ -55,7 +56,7 @@ func Test_Number(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := numberRegistryF.Format(tt.input, tt.options)
+			actual, err := numberRegistryF.Format(tt.input, tt.options, language.AmericanEnglish)
 
 			if tt.expectedErr {
 				require.Error(t, err)

--- a/template/registry/registry.go
+++ b/template/registry/registry.go
@@ -12,11 +12,10 @@ type Registry map[string]Func
 
 // Func is a function that can be used in formatting and matching contexts.
 type Func struct {
-	FormatSignature *Signature                                           // Signature of the function when called in formatting context
-	MatchSignature  *Signature                                           // Signature of the function when called in matching context
-	Fn              func(any, map[string]any, language.Tag) (any, error) // Function itself
-	Name            string
-	Description     string
+	FormatSignature, MatchSignature *Signature // Function signature when called in formatting or matching context
+	Func                            func(any, map[string]any, language.Tag) (any, error)
+	Name                            string
+	Description                     string
 }
 
 // Signature is a signature of the function, i.e. what input and options are allowed.
@@ -56,7 +55,7 @@ func (f *Func) Format(input any, options map[string]any, locale language.Tag) (a
 		return "", fmt.Errorf("check input: %w", err)
 	}
 
-	return f.Fn(input, options, locale)
+	return f.Func(input, options, locale)
 }
 
 func (f *Func) Match(input any, options map[string]any, locale language.Tag) (any, error) {
@@ -68,7 +67,7 @@ func (f *Func) Match(input any, options map[string]any, locale language.Tag) (an
 		return "", fmt.Errorf("check input: %w", err)
 	}
 
-	return f.Fn(input, options, locale)
+	return f.Func(input, options, locale)
 }
 
 func (s *Signature) check(input any, options map[string]any) error {

--- a/template/registry/registry.go
+++ b/template/registry/registry.go
@@ -4,15 +4,17 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"golang.org/x/text/language"
 )
 
 type Registry map[string]Func
 
 // Func is a function that can be used in formatting and matching contexts.
 type Func struct {
-	FormatSignature *Signature                             // Signature of the function when called in formatting context
-	MatchSignature  *Signature                             // Signature of the function when called in matching context
-	Fn              func(any, map[string]any) (any, error) // Function itself
+	FormatSignature *Signature                                           // Signature of the function when called in formatting context
+	MatchSignature  *Signature                                           // Signature of the function when called in matching context
+	Fn              func(any, map[string]any, language.Tag) (any, error) // Function itself
 	Name            string
 	Description     string
 }
@@ -45,7 +47,7 @@ func New() Registry {
 	}
 }
 
-func (f *Func) Format(input any, options map[string]any) (any, error) {
+func (f *Func) Format(input any, options map[string]any, locale language.Tag) (any, error) {
 	if f.FormatSignature == nil {
 		return "", fmt.Errorf("function '%s' is not allowed to use in formatting context", f.Name)
 	}
@@ -54,10 +56,10 @@ func (f *Func) Format(input any, options map[string]any) (any, error) {
 		return "", fmt.Errorf("check input: %w", err)
 	}
 
-	return f.Fn(input, options)
+	return f.Fn(input, options, locale)
 }
 
-func (f *Func) Match(input any, options map[string]any) (any, error) {
+func (f *Func) Match(input any, options map[string]any, locale language.Tag) (any, error) {
 	if f.MatchSignature == nil {
 		return "", fmt.Errorf("function '%s' is not allowed to use in selector context", f.Name)
 	}
@@ -66,7 +68,7 @@ func (f *Func) Match(input any, options map[string]any) (any, error) {
 		return "", fmt.Errorf("check input: %w", err)
 	}
 
-	return f.Fn(input, options)
+	return f.Fn(input, options, locale)
 }
 
 func (s *Signature) check(input any, options map[string]any) error {

--- a/template/registry/string.go
+++ b/template/registry/string.go
@@ -13,7 +13,7 @@ var stringRegistryF = &Func{
 	Description:     "Formatting of strings as a literal and selection based on string equality",
 	FormatSignature: &Signature{IsInputRequired: true},
 	MatchSignature:  &Signature{IsInputRequired: true},
-	Fn:              stringF,
+	Func:            stringF,
 }
 
 func stringF(input any, _ map[string]any, locale language.Tag) (any, error) {

--- a/template/registry/string.go
+++ b/template/registry/string.go
@@ -1,6 +1,10 @@
 package registry
 
-import "fmt"
+import (
+	"fmt"
+
+	"golang.org/x/text/language"
+)
 
 // https://github.com/unicode-org/message-format-wg/blob/20a61b4af534acb7ecb68a3812ca0143b34dfc76/spec/registry.xml#L259
 
@@ -12,7 +16,7 @@ var stringRegistryF = &Func{
 	Fn:              stringF,
 }
 
-func stringF(input any, _ map[string]any) (any, error) {
+func stringF(input any, _ map[string]any, locale language.Tag) (any, error) {
 	switch v := input.(type) {
 	case fmt.Stringer:
 		return v.String(), nil

--- a/template/registry/string_test.go
+++ b/template/registry/string_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
 )
 
 func Test_String(t *testing.T) {
@@ -51,7 +52,7 @@ func Test_String(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := stringRegistryF.Format(tt.input, tt.options)
+			actual, err := stringRegistryF.Format(tt.input, tt.options, language.AmericanEnglish)
 
 			if tt.expectedErr {
 				require.Error(t, err)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -49,7 +49,7 @@ func Test_ExecuteSimpleMessage(t *testing.T) {
 				{
 					Name:            "randName",
 					FormatSignature: &registry.Signature{},
-					Fn:              func(any, map[string]any, language.Tag) (any, error) { return "John", nil },
+					Func:            func(any, map[string]any, language.Tag) (any, error) { return "John", nil },
 				},
 			},
 			expected: "Hello, John",
@@ -97,7 +97,7 @@ func Test_ExecuteComplexMessage(t *testing.T) {
 				{
 					Name:            "randNum",
 					FormatSignature: &registry.Signature{},
-					Fn:              func(any, map[string]any, language.Tag) (any, error) { return 0, nil },
+					Func:            func(any, map[string]any, language.Tag) (any, error) { return 0, nil },
 				},
 			},
 			expected: "Hello, literalExpression World 0!",
@@ -249,7 +249,7 @@ func Test_ExecuteErrors(t *testing.T) {
 				{
 					Name:            "error",
 					FormatSignature: &registry.Signature{},
-					Fn:              func(any, map[string]any, language.Tag) (any, error) { return nil, errors.New("error") },
+					Func:            func(any, map[string]any, language.Tag) (any, error) { return nil, errors.New("error") },
 				},
 			},
 		},

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.expect.digital/mf2/template/registry"
+	"golang.org/x/text/language"
 )
 
 func Test_ExecuteSimpleMessage(t *testing.T) {
@@ -48,7 +49,7 @@ func Test_ExecuteSimpleMessage(t *testing.T) {
 				{
 					Name:            "randName",
 					FormatSignature: &registry.Signature{},
-					Fn:              func(_ any, _ map[string]any) (any, error) { return "John", nil },
+					Fn:              func(any, map[string]any, language.Tag) (any, error) { return "John", nil },
 				},
 			},
 			expected: "Hello, John",
@@ -60,12 +61,8 @@ func Test_ExecuteSimpleMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			template, err := New().Parse(tt.text)
+			template, err := New(WithFuncs(tt.funcs)).Parse(tt.text)
 			require.NoError(t, err)
-
-			for _, f := range tt.funcs {
-				template.AddFunc(f)
-			}
 
 			actual, err := template.Sprint(tt.input)
 			require.NoError(t, err)
@@ -100,7 +97,7 @@ func Test_ExecuteComplexMessage(t *testing.T) {
 				{
 					Name:            "randNum",
 					FormatSignature: &registry.Signature{},
-					Fn:              func(_ any, _ map[string]any) (any, error) { return 0, nil },
+					Fn:              func(any, map[string]any, language.Tag) (any, error) { return 0, nil },
 				},
 			},
 			expected: "Hello, literalExpression World 0!",
@@ -123,12 +120,8 @@ func Test_ExecuteComplexMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			template, err := New().Parse(tt.text)
+			template, err := New(WithFuncs(tt.funcs)).Parse(tt.text)
 			require.NoError(t, err)
-
-			for _, f := range tt.funcs {
-				template.AddFunc(f)
-			}
 
 			actual, err := template.Sprint(tt.inputs)
 			require.NoError(t, err)
@@ -221,7 +214,7 @@ func Test_ExecuteErrors(t *testing.T) {
 		name, text string
 		input      map[string]any
 		expected   expected
-		fn         []registry.Func // format function to be added before executing
+		funcs      []registry.Func // format function to be added before executing
 	}{
 		{
 			name:     "syntax error",
@@ -252,11 +245,11 @@ func Test_ExecuteErrors(t *testing.T) {
 			name:     "formatting error",
 			text:     "Hello, { :error }!",
 			expected: expected{execErr: ErrFormatting, text: "Hello, !"},
-			fn: []registry.Func{
+			funcs: []registry.Func{
 				{
 					Name:            "error",
 					FormatSignature: &registry.Signature{},
-					Fn:              func(any, map[string]any) (any, error) { return nil, errors.New("error") },
+					Fn:              func(any, map[string]any, language.Tag) (any, error) { return nil, errors.New("error") },
 				},
 			},
 		},
@@ -296,14 +289,10 @@ func Test_ExecuteErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			template, err := New().Parse(tt.text)
+			template, err := New(WithFuncs(tt.funcs)).Parse(tt.text)
 			if tt.expected.parseErr != nil {
 				require.ErrorIs(t, err, tt.expected.parseErr)
 				return
-			}
-
-			for _, f := range tt.fn {
-				template.AddFunc(f)
 			}
 
 			text, err := template.Sprint(tt.input)

--- a/wg_test.go
+++ b/wg_test.go
@@ -15,7 +15,7 @@ type WgTest struct {
 	// The MF2 message to be tested.
 	Src string `json:"src"`
 	// The locale to use for formatting. Defaults to 'en-US'.
-	Locale *language.Tag `json:"local"`
+	Locale *language.Tag `json:"locale"`
 	// Parameters to pass in to the formatter for resolving external variables.
 	Params map[string]any `json:"params"`
 	// The expected result of formatting the message to a string.
@@ -112,7 +112,12 @@ func TestWgFunctions(t *testing.T) {
 func assertWgTest(t *testing.T, test WgTest) {
 	t.Helper()
 
-	templ, err := template.New().Parse(test.Src)
+	var options []template.Option
+	if test.Locale != nil {
+		options = append(options, template.WithLocale(*test.Locale))
+	}
+
+	templ, err := template.New(options...).Parse(test.Src)
 	require.NoError(t, err)
 
 	actual, err := templ.Sprint(test.Params)


### PR DESCRIPTION
Pass the following MF2 WG test. Relates to #60.

```json
{
    "src": "{$one} et {$two}",
    "locale": "fr",
    "params": { "one": 1.3, "two": 4.2 },
    "exp": "1,3 et 4,2"
}
```