### PR TITLE
#60 - pass "{$one} et {$two}" MF2 WG core test

### DIFF
--- a/template/registry/datetime.go
+++ b/template/registry/datetime.go
@@ -10,10 +10,10 @@ import (
 
 // https://github.com/unicode-org/message-format-wg/blob/20a61b4af534acb7ecb68a3812ca0143b34dfc76/spec/registry.xml#L13
 
-var datetimeRegistryF = &Func{
+var datetimeRegistryFunc = &Func{
 	Name:           "datetime",
 	Description:    "Locale-sensitive date and time formatting",
-	Func:           datetimeF,
+	Func:           datetimeFunc,
 	MatchSignature: nil, // Not allowed to use in matching context
 	FormatSignature: &Signature{
 		IsInputRequired: true,
@@ -127,7 +127,7 @@ such as "Asia/Shanghai", "Asia/Kolkata", "America/New_York".`,
 	},
 }
 
-func datetimeF(a any, options map[string]any, locale language.Tag) (any, error) {
+func datetimeFunc(a any, options map[string]any, locale language.Tag) (any, error) {
 	if len(options) == 0 {
 		return fmt.Sprint(a), nil
 	}

--- a/template/registry/datetime_test.go
+++ b/template/registry/datetime_test.go
@@ -70,7 +70,7 @@ func Test_Datetime(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := datetimeRegistryF.Format(tt.input, tt.options, language.AmericanEnglish)
+			actual, err := datetimeRegistryFunc.Format(tt.input, tt.options, language.AmericanEnglish)
 
 			if tt.expectedErr {
 				require.Error(t, err)

--- a/template/registry/number.go
+++ b/template/registry/number.go
@@ -13,10 +13,10 @@ import (
 
 // https://github.com/unicode-org/message-format-wg/blob/20a61b4af534acb7ecb68a3812ca0143b34dfc76/spec/registry.xml#L147
 
-var numberRegistryF = &Func{
+var numberRegistryFunc = &Func{
 	Name:           "number",
 	Description:    "Locale-sensitive number formatting",
-	Func:           numberF,
+	Func:           numberFunc,
 	MatchSignature: nil, // Not allowed to use in matching context
 	FormatSignature: &Signature{
 		IsInputRequired: true,
@@ -155,14 +155,10 @@ the default for percent formatting is the larger of minimumFractionDigits and 0.
 }
 
 // TODO: supports only style and signDisplay options.
-func numberF(input any, options map[string]any, locale language.Tag) (any, error) {
+func numberFunc(input any, options map[string]any, locale language.Tag) (any, error) {
 	num, err := castAs[float64](input)
 	if err != nil {
 		return nil, fmt.Errorf("convert input to float64: %w", err)
-	}
-
-	if len(options) == 0 {
-		return num, nil
 	}
 
 	for optName := range options {
@@ -174,11 +170,13 @@ func numberF(input any, options map[string]any, locale language.Tag) (any, error
 		}
 	}
 
-	var result string
+	var (
+		result string
+		style  any = "decimal"
+	)
 
-	style, ok := options["style"]
-	if !ok {
-		style = "decimal"
+	if s, ok := options["style"]; ok {
+		style = s
 	}
 
 	p := message.NewPrinter(locale)

--- a/template/registry/number_test.go
+++ b/template/registry/number_test.go
@@ -21,7 +21,7 @@ func Test_Number(t *testing.T) {
 		{
 			name:     "int",
 			input:    53,
-			expected: float64(53),
+			expected: "53",
 		},
 		{
 			name:     "style",
@@ -56,7 +56,7 @@ func Test_Number(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := numberRegistryF.Format(tt.input, tt.options, language.AmericanEnglish)
+			actual, err := numberRegistryFunc.Format(tt.input, tt.options, language.AmericanEnglish)
 
 			if tt.expectedErr {
 				require.Error(t, err)

--- a/template/registry/registry.go
+++ b/template/registry/registry.go
@@ -40,9 +40,9 @@ type Options []Option
 // New returns a new registry with default functions.
 func New() Registry {
 	return Registry{
-		"string":   *stringRegistryF,
-		"number":   *numberRegistryF,
-		"datetime": *datetimeRegistryF,
+		"string":   *stringRegistryFunc,
+		"number":   *numberRegistryFunc,
+		"datetime": *datetimeRegistryFunc,
 	}
 }
 

--- a/template/registry/string.go
+++ b/template/registry/string.go
@@ -8,15 +8,15 @@ import (
 
 // https://github.com/unicode-org/message-format-wg/blob/20a61b4af534acb7ecb68a3812ca0143b34dfc76/spec/registry.xml#L259
 
-var stringRegistryF = &Func{
+var stringRegistryFunc = &Func{
 	Name:            "string",
 	Description:     "Formatting of strings as a literal and selection based on string equality",
 	FormatSignature: &Signature{IsInputRequired: true},
 	MatchSignature:  &Signature{IsInputRequired: true},
-	Func:            stringF,
+	Func:            stringFunc,
 }
 
-func stringF(input any, _ map[string]any, locale language.Tag) (any, error) {
+func stringFunc(input any, _ map[string]any, locale language.Tag) (any, error) {
 	switch v := input.(type) {
 	case fmt.Stringer:
 		return v.String(), nil

--- a/template/registry/string_test.go
+++ b/template/registry/string_test.go
@@ -52,7 +52,7 @@ func Test_String(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := stringRegistryF.Format(tt.input, tt.options, language.AmericanEnglish)
+			actual, err := stringRegistryFunc.Format(tt.input, tt.options, language.AmericanEnglish)
 
 			if tt.expectedErr {
 				require.Error(t, err)

--- a/wg_test.go
+++ b/wg_test.go
@@ -61,7 +61,7 @@ func TestWgSyntaxErrors(t *testing.T) {
 var wgCore []byte
 
 func TestWgCore(t *testing.T) {
-	t.Skip() // TODO(jhorsts): tests fail, fix in smaller PRs.
+	t.Skip() // TODO(jhorsts): tests fail, fix in smaller PRs. Issue #60
 	t.Parallel()
 
 	var tests []WgTest


### PR DESCRIPTION
Pass MF2 WG core test. Previous PR did not resolve it fully (DOH!).

This change adds default number formatting.

```json
  {
    "src": "{$one} et {$two}",
    "locale": "fr",
    "params": { "one": 1.3, "two": 4.2 },
    "exp": "1,3 et 4,2"
  }
```

