### PR TITLE
update min go version to v1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,17 +9,14 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.18", "1.22"]
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: "true"
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: "go.mod"
       - name: Test
         run: go test -v ./...
       - name: golangci-lint

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 ![CI](https://github.com/expect-digital/go-mf2/actions/workflows/ci.yaml/badge.svg)
 
 This parser parses the localized message strings based on the [Message Format 2 Draft](https://github.com/unicode-org/message-format-wg/blob/20a61b4af534acb7ecb68a3812ca0143b34dfc76/spec/message.abnf) by the Message Format Working Group (MFWG).
+
+# Requirements
+
+- Golang 1.22+

--- a/builder_test.go
+++ b/builder_test.go
@@ -223,8 +223,6 @@ func Test_Builder(t *testing.T) {
 			"{ #open opt1 = val1 opt2 = $var @attr1 = 1 } something { /close @empty1 @attr1 = $var }{ #selfClosing @attr1 = |༼ つ ◕_◕ ༽つ| /}{ #nest1 }{ #nest2 }nested{ #nest3 /}{ /nest2 }{ /nest1 }",
 		},
 	} {
-		test := test
-
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.expect.digital/mf2
 
-go 1.18
+go 1.22
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -505,8 +505,6 @@ func Test_lex(t *testing.T) {
 			},
 		},
 	} {
-		test := test
-
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -54,7 +54,7 @@ func (p *parser) current() item {
 
 func (p *parser) collect() error {
 	// sanity check, avoid infinite loop
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		itm := p.lexer.nextItem()
 		if itm.typ == itemError {
 			return fmt.Errorf("got error token: %s", itm.val)

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -326,29 +326,28 @@ func TestParseSimpleMessage(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := Parse(tt.input)
+			actual, err := Parse(test.input)
 			require.NoError(t, err)
 
 			// Check that AST message is equal to expected one.
-			require.Equal(t, tt.expected, actual.Message)
+			require.Equal(t, test.expected, actual.Message)
 
 			// Check that AST message converted back to string is equal to input.
 
 			// Edge case: scientific notation number is converted to normal notation, hence comparison is bound to fail.
 			// I.E. input string has 1e3, output string has 1000.
-			if tt.name == "unquoted scientific notation number literal expression" {
+			if test.name == "unquoted scientific notation number literal expression" {
 				return
 			}
 
 			// If strings already match, we're done.
 			// Otherwise check both sanitized strings.
-			if actualStr := actual.String(); actualStr != tt.input {
-				requireEqualMF2String(t, tt.input, actualStr)
+			if actualStr := actual.String(); actualStr != test.input {
+				requireEqualMF2String(t, test.input, actualStr)
 			}
 		})
 	}
@@ -724,23 +723,22 @@ no no {{Hello!}}`,
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := Parse(tt.input)
+			actual, err := Parse(test.input)
 			require.NoError(t, err)
 
 			// Check that AST message is equal to expected one.
-			require.Equal(t, tt.expected, actual.Message)
+			require.Equal(t, test.expected, actual.Message)
 
 			// Check that AST message converted back to string is equal to input.
 
 			// If strings already match, we're done.
 			// Otherwise check both sanitized strings.
-			if actualStr := actual.String(); actualStr != tt.input {
-				requireEqualMF2String(t, tt.input, actualStr)
+			if actualStr := actual.String(); actualStr != test.input {
+				requireEqualMF2String(t, test.input, actualStr)
 			}
 		})
 	}
@@ -894,16 +892,15 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			if tt.errorPath == "" {
+			if test.errorPath == "" {
 				require.FailNow(t, "test.errorPath is not set")
 			}
 
-			require.ErrorContains(t, tt.ast.validate(), tt.errorPath)
+			require.ErrorContains(t, test.ast.validate(), test.errorPath)
 		})
 	}
 }

--- a/template/registry/datetime_test.go
+++ b/template/registry/datetime_test.go
@@ -65,21 +65,20 @@ func Test_Datetime(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := datetimeRegistryFunc.Format(tt.input, tt.options, language.AmericanEnglish)
+			actual, err := datetimeRegistryFunc.Format(test.input, test.options, language.AmericanEnglish)
 
-			if tt.expectedErr {
+			if test.expectedErr {
 				require.Error(t, err)
 
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, actual)
+			require.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/template/registry/number_test.go
+++ b/template/registry/number_test.go
@@ -50,15 +50,13 @@ func Test_Number(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := numberRegistryFunc.Format(tt.input, tt.options, language.AmericanEnglish)
+			actual, err := numberRegistryFunc.Format(test.input, test.options, language.AmericanEnglish)
 
-			if tt.expectedErr {
+			if test.expectedErr {
 				require.Error(t, err)
 				require.Empty(t, actual)
 
@@ -66,7 +64,7 @@ func Test_Number(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, actual)
+			require.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/template/registry/string_test.go
+++ b/template/registry/string_test.go
@@ -46,15 +46,13 @@ func Test_String(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := stringRegistryFunc.Format(tt.input, tt.options, language.AmericanEnglish)
+			actual, err := stringRegistryFunc.Format(test.input, test.options, language.AmericanEnglish)
 
-			if tt.expectedErr {
+			if test.expectedErr {
 				require.Error(t, err)
 				require.Empty(t, actual)
 
@@ -62,7 +60,7 @@ func Test_String(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, actual)
+			require.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -184,8 +184,6 @@ func Test_Matcher(t *testing.T) {
 			require.NoError(t, err)
 
 			for i, inputMap := range test.inputs {
-				i, inputMap := i, inputMap
-
 				t.Run(test.expected[i], func(t *testing.T) {
 					t.Parallel()
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -56,18 +56,17 @@ func Test_ExecuteSimpleMessage(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			template, err := New(WithFuncs(tt.funcs)).Parse(tt.text)
+			template, err := New(WithFuncs(test.funcs)).Parse(test.text)
 			require.NoError(t, err)
 
-			actual, err := template.Sprint(tt.input)
+			actual, err := template.Sprint(test.input)
 			require.NoError(t, err)
 
-			require.Equal(t, tt.expected, actual)
+			require.Equal(t, test.expected, actual)
 		})
 	}
 }
@@ -115,18 +114,17 @@ func Test_ExecuteComplexMessage(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			template, err := New(WithFuncs(tt.funcs)).Parse(tt.text)
+			template, err := New(WithFuncs(test.funcs)).Parse(test.text)
 			require.NoError(t, err)
 
-			actual, err := template.Sprint(tt.inputs)
+			actual, err := template.Sprint(test.inputs)
 			require.NoError(t, err)
 
-			require.Equal(t, tt.expected, actual)
+			require.Equal(t, test.expected, actual)
 		})
 	}
 }
@@ -174,28 +172,27 @@ func Test_Matcher(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		if len(tt.inputs) != len(tt.expected) {
+	for _, test := range tests {
+		if len(test.inputs) != len(test.expected) {
 			t.Error("Arguments and expected results should have the same length")
 		}
 
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			template, err := New().Parse(tt.text)
+			template, err := New().Parse(test.text)
 			require.NoError(t, err)
 
-			for i, inputMap := range tt.inputs {
+			for i, inputMap := range test.inputs {
 				i, inputMap := i, inputMap
 
-				t.Run(tt.expected[i], func(t *testing.T) {
+				t.Run(test.expected[i], func(t *testing.T) {
 					t.Parallel()
 
 					actual, err := template.Sprint(inputMap)
 
 					require.NoError(t, err)
-					require.Equal(t, tt.expected[i], actual)
+					require.Equal(t, test.expected[i], actual)
 				})
 			}
 		})
@@ -284,20 +281,19 @@ func Test_ExecuteErrors(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			template, err := New(WithFuncs(tt.funcs)).Parse(tt.text)
-			if tt.expected.parseErr != nil {
-				require.ErrorIs(t, err, tt.expected.parseErr)
+			template, err := New(WithFuncs(test.funcs)).Parse(test.text)
+			if test.expected.parseErr != nil {
+				require.ErrorIs(t, err, test.expected.parseErr)
 				return
 			}
 
-			text, err := template.Sprint(tt.input)
-			require.ErrorIs(t, err, tt.expected.execErr)
-			assert.Equal(t, tt.expected.text, text)
+			text, err := template.Sprint(test.input)
+			require.ErrorIs(t, err, test.expected.execErr)
+			assert.Equal(t, test.expected.text, text)
 		})
 	}
 }

--- a/wg_test.go
+++ b/wg_test.go
@@ -41,8 +41,6 @@ func TestWgSyntaxErrors(t *testing.T) {
 	require.NoError(t, json.Unmarshal(wgSyntaxErrors, &inputs))
 
 	for _, input := range inputs {
-		input := input
-
 		t.Run(input, func(t *testing.T) {
 			t.Parallel()
 
@@ -69,8 +67,6 @@ func TestWgCore(t *testing.T) {
 	require.NoError(t, json.Unmarshal(wgCore, &tests))
 
 	for _, test := range tests {
-		test := test
-
 		t.Run(test.Src, func(t *testing.T) {
 			t.Parallel()
 
@@ -92,12 +88,8 @@ func TestWgFunctions(t *testing.T) {
 	require.NoError(t, err)
 
 	for funcName, funcTests := range tests {
-		funcTests := funcTests
-
 		t.Run(funcName, func(t *testing.T) {
 			for _, test := range funcTests {
-				test := test
-
 				t.Run(test.Src, func(t *testing.T) {
 					t.Parallel()
 


### PR DESCRIPTION
* Support the latest golang 1.22+
* Drop the support of the older golang versions

It simplifies error handling like `errorsJoin()` etc.