### PR TITLE
#60 - pass "foo {&private}" MF2 WG core test

### DIFF
--- a/template/template_test.go
+++ b/template/template_test.go
@@ -221,22 +221,22 @@ func Test_ExecuteErrors(t *testing.T) {
 			text:     "Hello, { $name }!",
 			expected: expected{execErr: ErrUnresolvedVariable, text: "Hello, {$name}!"},
 		},
-		{ // TODO(jhorsts): incomplete test (issue #60)
+		{
 			name:     "unknown function",
 			text:     "Hello, { :f }!",
 			expected: expected{execErr: ErrUnknownFunction, text: "Hello, !"},
 		},
-		{ // TODO(jhorsts): incomplete test (issue #60)
+		{
 			name:     "duplicate option name",
 			text:     "Hello, { :number style=decimal style=percent }!",
 			expected: expected{execErr: ErrDuplicateOptionName, text: "Hello, !"},
 		},
-		{ // TODO(jhorsts): incomplete test (issue #60)
+		{
 			name:     "unsupported expression",
 			text:     "Hello, { 12 ^private }!",
-			expected: expected{execErr: ErrUnsupportedExpression, text: "Hello, !"},
+			expected: expected{execErr: ErrUnsupportedExpression, text: "Hello, 12!"},
 		},
-		{ // TODO(jhorsts): incomplete test (issue #60)
+		{
 			name:     "formatting error",
 			text:     "Hello, { :error }!",
 			expected: expected{execErr: ErrFormatting, text: "Hello, !"},

--- a/wg_test.go
+++ b/wg_test.go
@@ -59,7 +59,7 @@ func TestWgSyntaxErrors(t *testing.T) {
 var wgCore []byte
 
 func TestWgCore(t *testing.T) {
-	t.Skip() // TODO(jhorsts): tests fail, fix in smaller PRs. Issue #60
+	// t.Skip() // TODO(jhorsts): tests fail, fix in smaller PRs. Issue #60
 	t.Parallel()
 
 	var tests []WgTest
@@ -126,6 +126,8 @@ func assertWgTest(t *testing.T, test WgTest) {
 			require.ErrorIs(t, err, template.ErrUnresolvedVariable)
 		case "unsupported-statement":
 			require.ErrorIs(t, err, template.ErrUnsupportedStatement)
+		case "unsupported-annotation":
+			require.ErrorIs(t, err, template.ErrUnsupportedExpression)
 		}
 	}
 

--- a/wg_test.go
+++ b/wg_test.go
@@ -59,7 +59,7 @@ func TestWgSyntaxErrors(t *testing.T) {
 var wgCore []byte
 
 func TestWgCore(t *testing.T) {
-	// t.Skip() // TODO(jhorsts): tests fail, fix in smaller PRs. Issue #60
+	t.Skip() // TODO(jhorsts): tests fail, fix in smaller PRs. Issue #60
 	t.Parallel()
 
 	var tests []WgTest


### PR DESCRIPTION
Pass the following MF2 WG test.

```json
  {
    "src": "foo {&private}",
    "exp": "foo {&}",
    "parts": [
      { "type": "literal", "value": "foo " },
      { "type": "fallback", "source": "&" }
    ],
    "errors": [{ "type": "unsupported-annotation" }]
  }
```