### PR TITLE
#60 - pass "hello {||}" MF2 WG core test

### DIFF
--- a/parse/ast.go
+++ b/parse/ast.go
@@ -270,13 +270,7 @@ func (QuotedLiteral) value()        {}
 func (QuotedLiteral) variantKey()   {}
 func (QuotedLiteral) reservedBody() {}
 
-func (l QuotedLiteral) validate() error {
-	if isZeroValue(l) {
-		return errors.New("quotedLiteral: literal is empty")
-	}
-
-	return nil
-}
+func (l QuotedLiteral) validate() error { return nil }
 
 type NameLiteral string
 


### PR DESCRIPTION
Pass the following MF2 WG test:

```json
{ "src": "hello {||}", "exp": "hello " },
```