### PR TITLE
60 pass "{/tag foo=bar}"

### DIFF
--- a/parse/ast.go
+++ b/parse/ast.go
@@ -270,13 +270,7 @@ func (QuotedLiteral) value()        {}
 func (QuotedLiteral) variantKey()   {}
 func (QuotedLiteral) reservedBody() {}
 
-func (l QuotedLiteral) validate() error {
-	if isZeroValue(l) {
-		return errors.New("quotedLiteral: literal is empty")
-	}
-
-	return nil
-}
+func (l QuotedLiteral) validate() error { return nil }
 
 type NameLiteral string
 

--- a/parse/ast.go
+++ b/parse/ast.go
@@ -691,10 +691,6 @@ func (m Markup) validate() error {
 		return fmt.Errorf("markup.%w", err)
 	}
 
-	if m.Typ == Close && len(m.Options) != 0 {
-		return errors.New("markup: options are not allowed for markup-close")
-	}
-
 	if err := validateSlice(m.Options); err != nil {
 		return fmt.Errorf("markup.%w", err)
 	}

--- a/parse/lex.go
+++ b/parse/lex.go
@@ -395,7 +395,6 @@ func lexExpr(l *lexer) stateFn {
 		l.backup()
 
 		return lexIdentifier(l)
-
 	case v == '{': // expression/markup start
 		l.isExpression = true
 
@@ -414,7 +413,8 @@ func lexExpr(l *lexer) stateFn {
 			l.prev.typ == itemUnquotedLiteral ||
 			l.prev.typ == itemNumberLiteral ||
 			l.prev.typ == itemVariable) ||
-		l.prev.typ == itemMarkupOpen:
+		l.prev.typ == itemMarkupOpen ||
+		l.prev.typ == itemMarkupClose:
 		l.backup()
 		return lexIdentifier(l)
 	case isReservedStart(v):

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -454,8 +454,10 @@ func Test_lex(t *testing.T) {
 			},
 		},
 		{
-			name:  "markup",
-			input: `{#button}Submit{/button}{#img alt=|Cancel| @hello=world @goodbye /}{ #nest1}{#nest2}text{#nest3/}{/nest2}{/nest1}`, //nolint: lll
+			name: "markup",
+			input: `{#button}Submit{/button}
+{#img alt=|Cancel| @hello=world @goodbye /}
+{ #nest1}{#nest2}text{#nest3/}{/nest2}{/nest1 a=b}`,
 			expected: []item{
 				// 1. simple open-close
 				mk(itemExpressionOpen, "{"),
@@ -465,6 +467,8 @@ func Test_lex(t *testing.T) {
 				mk(itemExpressionOpen, "{"),
 				mk(itemMarkupClose, "button"),
 				mk(itemExpressionClose, "}"),
+				mk(itemText, "\n"),
+
 				// 2. self-closing + options + attributes
 				mk(itemExpressionOpen, "{"),
 				mk(itemMarkupOpen, "img"),
@@ -481,6 +485,8 @@ func Test_lex(t *testing.T) {
 				mk(itemWhitespace, " "),
 				mk(itemMarkupClose, ""),
 				mk(itemExpressionClose, "}"),
+				mk(itemText, "\n"),
+
 				// 3. nested
 				mk(itemExpressionOpen, "{"),
 				mk(itemWhitespace, " "),
@@ -499,6 +505,10 @@ func Test_lex(t *testing.T) {
 				mk(itemExpressionClose, "}"),
 				mk(itemExpressionOpen, "{"),
 				mk(itemMarkupClose, "nest1"),
+				mk(itemWhitespace, " "),
+				mk(itemOption, "a"),
+				mk(itemOperator, "="),
+				mk(itemUnquotedLiteral, "b"),
 				mk(itemExpressionClose, "}"),
 				//
 				mk(itemEOF, ""),

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -285,10 +285,6 @@ func (p *parser) parseMarkup() (Markup, error) {
 			}
 
 		case itemOption:
-			if markup.Typ == Close {
-				return Markup{}, fmt.Errorf("close markup cannot have options: '%s'", itm.val)
-			}
-			// Markup with options
 			option, err := p.parseOption()
 			if err != nil {
 				return Markup{}, fmt.Errorf("parse option: %w", err)


### PR DESCRIPTION
Pass the following MF2 WG test:

```json
  {
    "src": "{/tag foo=bar}",
    "exp": "",
    "parts": [
      {
        "type": "markup",
        "kind": "close",
        "name": "tag",
        "options": { "foo": "bar" }
      }
    ]
  },
```