### PR TITLE
#60 - pass "{#tag a:foo=|foo| b:bar=$bar}" MF2 WG core test

### DIFF
--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -454,23 +454,6 @@ func Test_lex(t *testing.T) {
 			},
 		},
 		{
-			name:  "x",
-			input: "{#tag a:foo=|foo| b:bar=$bar}",
-			expected: []item{
-				mk(itemExpressionOpen, "{"),
-				mk(itemMarkupOpen, "tag"),
-				mk(itemWhitespace, " "),
-				mk(itemOption, "a:foo"),
-				mk(itemOperator, "="),
-				mk(itemQuotedLiteral, "foo"),
-				mk(itemWhitespace, " "),
-				mk(itemOption, "b:bar"),
-				mk(itemOperator, "="),
-				mk(itemVariable, "bar"),
-				mk(itemExpressionClose, "}"),
-			},
-		},
-		{
 			name: "markup",
 			input: `{#button}Submit{/button}
 {#img alt=|Cancel| @hello=world @goodbye /}

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -454,6 +454,23 @@ func Test_lex(t *testing.T) {
 			},
 		},
 		{
+			name:  "x",
+			input: "{#tag a:foo=|foo| b:bar=$bar}",
+			expected: []item{
+				mk(itemExpressionOpen, "{"),
+				mk(itemMarkupOpen, "tag"),
+				mk(itemWhitespace, " "),
+				mk(itemOption, "a:foo"),
+				mk(itemOperator, "="),
+				mk(itemQuotedLiteral, "foo"),
+				mk(itemWhitespace, " "),
+				mk(itemOption, "b:bar"),
+				mk(itemOperator, "="),
+				mk(itemVariable, "bar"),
+				mk(itemExpressionClose, "}"),
+			},
+		},
+		{
 			name: "markup",
 			input: `{#button}Submit{/button}
 {#img alt=|Cancel| @hello=world @goodbye /}
@@ -553,8 +570,8 @@ func logItem(t *testing.T, expected item, l lexer) func() {
 			return " "
 		}
 
-		t.Logf("c%s p%s e%s f%s r%s %-30s e%s(%s) a%s(%s)\n",
-			f(l.isComplexMessage), f(l.isPattern), f(l.isExpression), f(l.isFunction), f(l.isReservedBody),
+		t.Logf("c%s p%s e%s f%s r%s m%s %-30s e%s(%s) a%s(%s)\n",
+			f(l.isComplexMessage), f(l.isPattern), f(l.isExpression), f(l.isFunction), f(l.isReservedBody), f(l.isMarkup),
 			"'"+l.input[l.pos:]+"'", "'"+expected.val+"'", expected.typ, "'"+l.item.val+"'", l.item.typ)
 	}
 }

--- a/wg_test.go
+++ b/wg_test.go
@@ -59,7 +59,6 @@ func TestWgSyntaxErrors(t *testing.T) {
 var wgCore []byte
 
 func TestWgCore(t *testing.T) {
-	t.Skip() // TODO(jhorsts): tests fail, fix in smaller PRs. Issue #60
 	t.Parallel()
 
 	var tests []WgTest


### PR DESCRIPTION
Pass the following MF2 WG test:

```json
  {
    "src": "{#tag a:foo=|foo| b:bar=$bar}",
    "params": { "bar": "b a r" },
    "exp": "",
    "parts": [
      {
        "type": "markup",
        "kind": "open",
        "name": "tag",
        "options": { "a:foo": "foo", "b:bar": "b a r" }
      }
    ]
  },
```