### PR TITLE
add maximumFractionDigits option to number func

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ List of the default functions registered in the function registry. The functions
 | number                 | format    | unitDisplay                                   |   ❌   |
 | number                 | format    | minimumIntegerDigits                          |   ❌   |
 | number                 | format    | minimumFractionDigits                         |   ❌   |
-| number                 | format    | maximumFractionDigits                         |   ❌   |
+| number                 | format    | maximumFractionDigits                         |  ✅︎   |
 | number                 | format    | minimumSignificantDigits                      |   ❌   |
 | number                 | format    | maximumSignificantDigits                      |   ❌   |
 | number                 | match     | select                                        |   ❌   |

--- a/template/registry/number.go
+++ b/template/registry/number.go
@@ -165,27 +165,36 @@ func numberFunc(input any, options map[string]any, locale language.Tag) (any, er
 		switch optName {
 		case "compactDisplay", "currency", "currencyDisplay", "currencySign", "notation", "numberingSystem",
 			"unit", "unitDisplay", "minimumIntegerDigits", "minimumFractionDigits",
-			"maximumFractionDigits", "minimumSignificantDigits", "maximumSignificantDigits":
+			"minimumSignificantDigits", "maximumSignificantDigits":
 			return nil, fmt.Errorf("option '%s' is not implemented", optName)
 		}
 	}
 
 	var (
-		result string
-		style  any = "decimal"
+		result                string
+		style                 = "decimal"
+		maximumFractionDigits int // percent default
 	)
 
-	if s, ok := options["style"]; ok {
-		style = s
+	if v, ok := options["style"]; ok {
+		style = v.(string) //nolint:forcetypeassert
+	}
+
+	if style == "decimal" {
+		maximumFractionDigits = 3
+	}
+
+	if v, ok := options["maximumFractionDigits"]; ok {
+		maximumFractionDigits, _ = castAs[int](v)
 	}
 
 	p := message.NewPrinter(locale)
 
 	switch style {
 	case "decimal":
-		result = p.Sprint(number.Decimal(num))
+		result = p.Sprint(number.Decimal(num, number.MaxFractionDigits(maximumFractionDigits)))
 	case "percent":
-		result = p.Sprint(number.Percent(num))
+		result = p.Sprint(number.Percent(num, number.MaxFractionDigits(maximumFractionDigits)))
 	default:
 		return nil, fmt.Errorf("option '%s' is not implemented", style)
 	}

--- a/template/registry/number_test.go
+++ b/template/registry/number_test.go
@@ -12,9 +12,9 @@ func Test_Number(t *testing.T) {
 	// decimal
 
 	assert := assertFmt(t, numberRegistryFunc, nil, language.Latvian)
-	assert(-0.15, "-0,15")
+	assert(-0.1234, "-0,123")
 	assert(0, "0")
-	assert(0.15, "0,15")
+	assert(0.1234, "0,123")
 
 	assert = assertFmt(t, numberRegistryFunc, map[string]any{"signDisplay": "auto"}, language.AmericanEnglish)
 	assert(-0.15, "-0.15")
@@ -35,6 +35,9 @@ func Test_Number(t *testing.T) {
 	assert(-0.15, "0.15")
 	assert(0, "0")
 	assert(0.15, "0.15")
+
+	assert = assertFmt(t, numberRegistryFunc, map[string]any{"maximumFractionDigits": 1}, language.AmericanEnglish)
+	assert(0.15, "0.1")
 
 	// percent
 
@@ -66,4 +69,8 @@ func Test_Number(t *testing.T) {
 	assert(-0.127, "13%")
 	assert(0, "0%")
 	assert(0.127, "13%")
+
+	assert = assertFmt(t, numberRegistryFunc,
+		map[string]any{"style": "percent", "maximumFractionDigits": 1}, language.Latvian)
+	assert(0.127, "12,7%")
 }


### PR DESCRIPTION
The maximum number of fraction digits to use.
The default for plain number formatting is the larger of minimumFractionDigits and 3.
The default for percent formatting is the larger of minimumFractionDigits and 0.
