### PR TITLE
#60 - pass "{$x :datetime}" MF2 WG function test

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -308,17 +308,17 @@ func (e *executer) resolveExpression(expr ast.Expression) (string, error) {
 	}
 
 	fmtErroredExpr := func() string {
-		wrap := func(s string) string { return "{" + s + "}" }
+		wrap := func(s fmt.Stringer) string { return "{" + s.String() + "}" }
 
 		switch v := expr.Operand.(type) {
 		default:
-			return wrap(expr.Annotation.String())
+			return wrap(expr.Annotation)
 		case ast.Variable:
-			return wrap(v.String())
+			return wrap(v)
 		case ast.NameLiteral, ast.NumberLiteral:
-			return wrap(ast.QuotedLiteral(v.String()).String())
+			return wrap(ast.QuotedLiteral(v.String()))
 		case ast.QuotedLiteral:
-			return wrap(v.String())
+			return wrap(v)
 		}
 	}
 


### PR DESCRIPTION
Pass FM2 WG function test

```json
    {
      "src": "{$x :datetime}",
      "exp": "{$x}",
      "params": { "x": true },
      "errors": [{ "type": "bad-input" }]
    }
```