### PR TITLE
120 - improve error messaging in parse package

### DIFF
--- a/parse/lex.go
+++ b/parse/lex.go
@@ -119,7 +119,7 @@ type item struct {
 }
 
 func (i item) String() string {
-	return fmt.Sprintf(`%s "%s"`, i.typ, i.val)
+	return fmt.Sprintf(`%s token "%s"`, i.typ, i.val)
 }
 
 // mk creates a new item with the given type and value.

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -758,11 +758,11 @@ func TestParseErrors(t *testing.T) {
 	}{
 		{
 			in:      ".match {|foo| :x} {|bar| :x} ** {{foo}}",
-			wantErr: "parse message `.match {|foo| :x} {|bar| :x} ** {{foo}}`: parse matcher: parse variant keys: missing space between keys * and *", //nolint:lll
+			wantErr: "parse MF2: complex message: matcher: variant keys: missing space between keys * and *",
 		},
 		{
 			in:      ".match {|foo| :x} {|bar| :x} *1 {{foo}}",
-			wantErr: "parse message `.match {|foo| :x} {|bar| :x} *1 {{foo}}`: parse matcher: parse variant keys: missing space between keys * and 1", //nolint:lll
+			wantErr: "parse MF2: complex message: matcher: variant keys: missing space between keys * and 1",
 		},
 	} {
 		t.Run(test.in, func(t *testing.T) {


### PR DESCRIPTION
I ignored the errors in `validate()` functions in `ast.go`.

Very likely I'll apply verification at the point of building AST, and remove the `validate()` functions.