### PR TITLE
137 - sync errors definition with MF2 errors spec

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -228,7 +228,7 @@ func Test_Builder(t *testing.T) {
 			}
 
 			if test.want != got {
-				t.Errorf("want %s, got %s", test.want, got)
+				t.Errorf("want '%s', got '%s'", test.want, got)
 			}
 		})
 	}

--- a/errors.go
+++ b/errors.go
@@ -6,13 +6,13 @@ import "errors"
 //
 // [MF2 errors]: https://github.com/unicode-org/message-format-wg/blob/main/spec/errors.md
 var (
-	// ErrBadOperand is any error that occurs due to the content or format of the operand,
-	// such as when the operand provided to a function during function resolution does not match one of the
-	// expected implementation-defined types for that function;
-	// or in which a literal operand value does not have the required format
-	// and thus cannot be processed into one of the expected implementation-defined types
-	// for that specific function.
-	ErrBadOperand = errors.New("bad operand")
+	// SYNTAX ERRORS.
+
+	// ErrSyntax occurs when the syntax representation of a message is not well-formed.
+	ErrSyntax = errors.New("syntax error")
+
+	// DATA MODEL ERRORS.
+
 	// ErrDuplicateDeclaration occurs when a variable is declared more than once.
 	// Note that an input variable is implicitly declared when it is first used,
 	// so explicitly declaring it after such use is also an error.
@@ -20,7 +20,6 @@ var (
 	// ErrDuplicateOptionName occurs when the same identifier
 	// appears on the left-hand side of more than one option in the same expression.
 	ErrDuplicateOptionName = errors.New("duplicate option name")
-	ErrFormatting          = errors.New("formatting error")
 	// ErrMissingFallbackVariant occurs when the number of keys on a variant
 	// does not equal the number of selectors.
 	ErrMissingFallbackVariant = errors.New("missing fallback variant")
@@ -28,18 +27,15 @@ var (
 	// contains a selector that does not have an annotation,
 	// or contains a variable that does not directly or indirectly reference a declaration with an annotation.
 	ErrMissingSelectorAnnotation = errors.New("missing selector annotation")
-	// ErrOperandMismatch is an Invalid Expression error that occurs when an operand provided
-	// to a function during function resolution does not match one of the expected
-	// implementation-defined types for that function; or in which a literal operand value does not
-	// have the required format and thus cannot be processed into one of the expected
-	// implementation-defined types for that specific function.
-	ErrOperandMismatch = errors.New("operand mismatch")
-	ErrSelection       = errors.New("selection error")
-	// ErrSyntax occurs when the syntax representation of a message is not well-formed.
-	ErrSyntax = errors.New("syntax error")
+	// ErrVariantKeyMismatch occurs when the number of keys on a variant
+	// does not equal the number of selectors.
+	ErrVariantKeyMismatch = errors.New("variant key mismatch")
+
+	// RESOLUTION ERRORS.
+
 	// ErrUnknownFunction occurs when an expression includes
 	// a reference to a function which cannot be resolved.
-	ErrUnknownFunction = errors.New("unknown function reference")
+	ErrUnknownFunction = errors.New("unknown function")
 	// ErrUnresolvedVariable occurs when a variable reference cannot be resolved.
 	ErrUnresolvedVariable = errors.New("unresolved variable")
 	// ErrUnsupportedExpression occurs when an expression uses
@@ -48,7 +44,20 @@ var (
 	ErrUnsupportedExpression = errors.New("unsupported expression")
 	// ErrUnsupportedStatement occurs when a message includes a reserved statement.
 	ErrUnsupportedStatement = errors.New("unsupported statement")
-	// ErrVariantKeyMismatch occurs when the number of keys on a variant
-	// does not equal the number of selectors.
-	ErrVariantKeyMismatch = errors.New("variant key mismatch")
+
+	// MESSAGE FUNCTION ERRORS.
+
+	// ErrBadOperand is any error that occurs due to the content or format of the operand,
+	// such as when the operand provided to a function during function resolution does not match one of the
+	// expected implementation-defined types for that function;
+	// or in which a literal operand value does not have the required format
+	// and thus cannot be processed into one of the expected implementation-defined types
+	// for that specific function.
+	ErrBadOperand = errors.New("bad operand")
+	// ErrBadOption is an error that occurs when there is
+	// an implementation-defined error with an option or its value.
+	ErrBadOption = errors.New("bad option")
+	// ErrBadVariantKey is an error that occurs when a variant key
+	// does not match the expected implementation-defined format.
+	ErrBadVariantKey = errors.New("bad variant key")
 )

--- a/mf2wg_test.go
+++ b/mf2wg_test.go
@@ -182,7 +182,7 @@ func run(t *testing.T, test Test) {
 	// Expected is optional. The built-in formatters is implementation
 	// specific across programming languages and libraries.
 	if test.Exp != nil && *test.Exp != got {
-		t.Errorf("want %s, got %s", *test.Exp, got)
+		t.Errorf("want '%s', got '%s'", *test.Exp, got)
 	}
 }
 
@@ -281,7 +281,7 @@ func assertErr(t *testing.T, want Errors, err error) {
 
 	wantErr := func(want error) {
 		if !errors.Is(err, want) {
-			t.Errorf("want %s, got %s", want, err)
+			t.Errorf("want '%s', got '%s'", want, err)
 		}
 	}
 

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -736,7 +736,7 @@ no no {{Hello!}}`,
 
 			// Check that AST message is equal to expected one.
 			if test.want.String() != got.Message.String() {
-				t.Errorf("want %s, got %s", test.want, test.want)
+				t.Errorf("want '%s', got '%s'", test.want, test.want)
 			}
 
 			// Check that AST message converted back to string is equal to input.
@@ -769,7 +769,7 @@ func TestParseErrors(t *testing.T) {
 			t.Parallel()
 
 			if _, err := Parse(test.in); err == nil || err.Error() != test.wantErr {
-				t.Errorf("want %s, got %s", test.wantErr, err)
+				t.Errorf("want '%s', got '%s'", test.wantErr, err)
 			}
 		})
 	}
@@ -933,7 +933,7 @@ func TestValidate(t *testing.T) {
 
 			err := test.ast.validate()
 			if !strings.Contains(err.Error(), test.errorPath) {
-				t.Errorf("want %s, got %s", test.errorPath, err)
+				t.Errorf("want '%s', got '%s'", test.errorPath, err)
 			}
 		})
 	}
@@ -952,6 +952,6 @@ func requireEqualMF2String(t *testing.T, want, got string) {
 	)
 
 	if r.Replace(want) != r.Replace(got) {
-		t.Errorf("want %s, got %s", want, got)
+		t.Errorf("want '%s', got '%s'", want, got)
 	}
 }

--- a/template/example_test.go
+++ b/template/example_test.go
@@ -52,12 +52,12 @@ func ExampleTemplate_complexMessage() {
 
 	color := func(value any, options template.Options, locale language.Tag) (any, error) {
 		if value == nil {
-			return "", fmt.Errorf("input is required: %w", mf2.ErrOperandMismatch)
+			return "", fmt.Errorf("input is required: %w", mf2.ErrBadOperand)
 		}
 
 		color, ok := value.(string)
 		if !ok {
-			return nil, fmt.Errorf("input is not a string: %w", mf2.ErrOperandMismatch)
+			return nil, fmt.Errorf("input is not a string: %w", mf2.ErrBadOperand)
 		}
 
 		if options == nil {

--- a/template/registry_datetime.go
+++ b/template/registry_datetime.go
@@ -58,17 +58,17 @@ type datetimeOptions struct {
 
 func parseDatetimeInput(input any) (time.Time, error) {
 	if input == nil {
-		return time.Time{}, fmt.Errorf("input is required: %w", mf2.ErrOperandMismatch)
+		return time.Time{}, fmt.Errorf("input is required: %w", mf2.ErrBadOperand)
 	}
 
 	switch v := input.(type) {
 	default:
-		return time.Time{}, fmt.Errorf("unsupported datetime type %T: %w", input, mf2.ErrOperandMismatch)
+		return time.Time{}, fmt.Errorf("unsupported datetime type %T: %w", input, mf2.ErrBadOperand)
 	case string:
 		// layout is quick and dirty, does not conform with ISO 8601 fully as required
 		t, err := time.Parse(time.RFC3339[:len(v)], v)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("parse datetime %s: %w", v, mf2.ErrOperandMismatch)
+			return time.Time{}, fmt.Errorf("parse datetime %s: %w", v, mf2.ErrBadOperand)
 		}
 
 		return t, nil

--- a/template/registry_datetime_test.go
+++ b/template/registry_datetime_test.go
@@ -83,7 +83,7 @@ func Test_Datetime(t *testing.T) {
 			}
 
 			if test.want != got {
-				t.Errorf("want %s, got %s", test.want, got)
+				t.Errorf("want '%s', got '%s'", test.want, got)
 			}
 		})
 	}

--- a/template/registry_number.go
+++ b/template/registry_number.go
@@ -21,12 +21,12 @@ var numberRegistryFunc = RegistryFunc{
 
 func parseNumberInput(input any) (float64, error) {
 	if input == nil {
-		return 0, fmt.Errorf("input is required: %w", mf2.ErrOperandMismatch)
+		return 0, fmt.Errorf("input is required: %w", mf2.ErrBadOperand)
 	}
 
 	v, err := castAs[float64](input)
 	if err != nil {
-		return 0, fmt.Errorf("unsupported type %T: %w: %w", input, err, mf2.ErrOperandMismatch)
+		return 0, fmt.Errorf("unsupported type %T: %w: %w", input, err, mf2.ErrBadOperand)
 	}
 
 	return v, nil

--- a/template/registry_string_test.go
+++ b/template/registry_string_test.go
@@ -66,7 +66,7 @@ func Test_String(t *testing.T) {
 			}
 
 			if test.want != got {
-				t.Errorf("want %s, got %s", test.want, got)
+				t.Errorf("want '%s', got '%s'", test.want, got)
 			}
 		})
 	}

--- a/template/registry_test.go
+++ b/template/registry_test.go
@@ -16,7 +16,7 @@ func assertFormat(t *testing.T, f RegistryFunc, options map[string]any, locale l
 		}
 
 		if want != result {
-			t.Errorf("want %s, got %s", want, result)
+			t.Errorf("want '%s', got '%s'", want, result)
 		}
 	}
 }

--- a/template/template.go
+++ b/template/template.go
@@ -322,7 +322,7 @@ func (e *executer) resolveExpression(expr ast.Expression) (string, error) {
 
 	result, err := f.Format(value, options, e.template.locale)
 	if err != nil {
-		return fmtErroredExpr(), errors.Join(resolutionErr, mf2.ErrFormatting, err)
+		return fmtErroredExpr(), errors.Join(resolutionErr, err)
 	}
 
 	return fmt.Sprint(result), resolutionErr
@@ -430,7 +430,7 @@ func (e *executer) resolveSelector(matcher ast.Matcher) ([]any, error) {
 
 		rslt, err := f.Match(input, opts, e.template.locale)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %s", mf2.ErrSelection, err.Error())
+			return nil, err
 		}
 
 		res = append(res, rslt)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -67,7 +67,7 @@ func Test_ExecuteSimpleMessage(t *testing.T) {
 			}
 
 			if test.want != got {
-				t.Errorf("want %s, got %s", test.want, got)
+				t.Errorf("want '%s', got '%s'", test.want, got)
 			}
 		})
 	}
@@ -129,7 +129,7 @@ func Test_ExecuteComplexMessage(t *testing.T) {
 			}
 
 			if test.want != got {
-				t.Errorf("want %s, got %s", test.want, got)
+				t.Errorf("want '%s', got '%s'", test.want, got)
 			}
 		})
 	}
@@ -200,7 +200,7 @@ func Test_Matcher(t *testing.T) {
 					}
 
 					if test.want[i] != got {
-						t.Errorf(`want "%s" at %d, got "%s"`, test.want[i], i, got)
+						t.Errorf("want '%s' at %d, got '%s'", test.want[i], i, got)
 					}
 				})
 			}
@@ -248,16 +248,6 @@ func Test_ExecuteErrors(t *testing.T) {
 			want: want{execErr: mf2.ErrUnsupportedExpression, text: "Hello, 12!"},
 		},
 		{
-			name: "formatting error",
-			text: "Hello, { :error }!",
-			want: want{execErr: mf2.ErrFormatting, text: "Hello, {:error}!"},
-			funcs: Registry{
-				"error": {
-					Format: func(any, Options, language.Tag) (any, error) { return nil, errors.New("error") },
-				},
-			},
-		},
-		{
 			name: "unsupported declaration",
 			text: ".reserved { name } {{Hello!}}",
 			want: want{execErr: mf2.ErrUnsupportedStatement, text: "Hello!"},
@@ -295,7 +285,7 @@ func Test_ExecuteErrors(t *testing.T) {
 			template, err := New(WithFuncs(test.funcs)).Parse(test.text)
 			if test.want.parseErr != nil {
 				if !errors.Is(err, test.want.parseErr) {
-					t.Errorf("want %s, got %s", test.want.parseErr, err)
+					t.Errorf("want '%s', got '%s'", test.want.parseErr, err)
 				}
 
 				return
@@ -303,11 +293,11 @@ func Test_ExecuteErrors(t *testing.T) {
 
 			text, err := template.Sprint(test.input)
 			if !errors.Is(err, test.want.execErr) {
-				t.Errorf("want %s, got %s", test.want.execErr, err)
+				t.Errorf("want '%s', got '%s'", test.want.execErr, err)
 			}
 
 			if test.want.text != text {
-				t.Errorf(`want "%s", got "%s"`, test.want.text, text)
+				t.Errorf("want '%s', got '%s'", test.want.text, text)
 			}
 		})
 	}


### PR DESCRIPTION
* ensured errors are the same as in the MF2 spec
* wrapped all error strings with single quotes in the unit tests to make reading easier in the terminal.